### PR TITLE
Do not open networks from files with older format version than the installed pandapower version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Change Log
 -------------------------------
 - [FIXED] cim2pp shift_lv_degree was translated from wrong entry
 - [FIXED] UnboundLocalError in _from_ppc_branch when creating impedance elements
+- [ADDED] LTDS support
 
 
 [3.4.0] - 2026-02-09

--- a/pandapower/convert_format.py
+++ b/pandapower/convert_format.py
@@ -21,7 +21,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def convert_format(net, elements_to_deserialize=None, drop_invalid_geodata=False):
+def convert_format(net, elements_to_deserialize=None, drop_invalid_geodata=False,
+                   donot_open_newer=True):
     """
     Converts old nets to new format to ensure consistency. The converted net is returned.
     """
@@ -31,6 +32,14 @@ def convert_format(net, elements_to_deserialize=None, drop_invalid_geodata=False
     if Version(str(net.format_version)) > Version(str(net.version).split('.dev')[0]):
         # TODO: create error/warning when pandapower version is older then network
         net.format_version = net.version
+    if Version(net.format_version) > Version(__format_version__):
+        msg1 = (f"The network format version {net.format_version} is newer than the current "
+                f"pandapower version {__format_version__}. ")
+        if donot_open_newer:
+            msg = msg1 + "Please update pandapower to the latest version."
+            raise ValueError(msg)
+        else:
+            logger.warning(msg1 + "Some features may not work as expected.")
     if isinstance(net.format_version, str) and Version(net.format_version) >= Version(__format_version__):
         return net
     _add_nominal_power(net)

--- a/pandapower/converter/cim/cim2pp/build_pp_net.py
+++ b/pandapower/converter/cim/cim2pp/build_pp_net.py
@@ -26,9 +26,10 @@ sc = cim_tools.get_pp_net_special_columns_dict()
 
 class CimConverter:
 
-    def __init__(self, cim_parser: cim_classes.CimParser, converter_classes: Dict, **kwargs):
+    def __init__(self, cim_parser: cim_classes.CimParser, converter_classes: Dict, cim_version: str, **kwargs):
         self.logger = logging.getLogger(self.__class__.__name__)
         self.cim_parser: cim_classes.CimParser = cim_parser
+        self.cim_version = cim_version.lower()
         self.kwargs = kwargs
         self.cim: Dict[str, Dict[str, pd.DataFrame]] = self.cim_parser.get_cim_dict()
         self.net: pandapowerNet = create_empty_network()
@@ -37,6 +38,7 @@ class CimConverter:
         self.power_trafo3w: pd.DataFrame = pd.DataFrame()
         self.report_container: ReportContainer = cim_parser.get_report_container()
         self.classes_dict = converter_classes
+        self.ignore_errors = bool(kwargs.get('ignore_errors', True))
 
     def merge_eq_ssh_profile(self, cim_type: str, add_cim_type_column: bool = False) -> pd.DataFrame:
         return self.merge_eq_other_profiles(['ssh'], cim_type, add_cim_type_column)
@@ -163,8 +165,9 @@ class CimConverter:
                     message="Creating the coordinates failed, returning the net without coordinates!"))
                 self.report_container.add_log(Report(level=LogLevel.EXCEPTION, code=ReportCode.EXCEPTION_CONVERTING,
                                                      message=traceback.format_exc()))
-        self.net = pp_tools.set_pp_col_types(net=self.net)
 
+        # set the datatypes after the conversion, especially for integer and boolean columns
+        self.net = pp_tools.set_pp_col_types(net=self.net)
         # create transformer tap controller
         self.classes_dict['tapController'](cimConverter=self).create_tap_controller_for_power_transformers()
 
@@ -181,13 +184,14 @@ class CimConverter:
                     level=LogLevel.ERROR, code=ReportCode.ERROR, message="Failed running a powerflow."))
                 self.report_container.add_log(Report(level=LogLevel.EXCEPTION, code=ReportCode.EXCEPTION,
                                                      message=traceback.format_exc()))
-                if not kwargs.get('ignore_errors', True):
+                if not self.ignore_errors:
                     raise e
             else:
                 self.logger.info("Power flow solved normal.")
                 self.report_container.add_log(Report(
                     level=LogLevel.INFO, code=ReportCode.INFO, message="Power flow solved normal."))
         try:
+            # SV: StateVariables (loadflow results), Analog: raw measurements from field
             create_measurements = kwargs.get('create_measurements', None)
             if create_measurements is not None and create_measurements.lower() == 'sv':
                 CreateMeasurements(self.net, self.cim).create_measurements_from_sv()
@@ -210,7 +214,7 @@ class CimConverter:
                 level=LogLevel.EXCEPTION, code=ReportCode.EXCEPTION_CONVERTING,
                 message=traceback.format_exc()))
             self.net.measurement = self.net.measurement[0:0]
-            if not kwargs.get('ignore_errors', True):
+            if not self.ignore_errors:
                 raise e
         # a special fix for BB and NB mixed networks:
         # fuse boundary ConnectivityNodes with their TopologicalNodes
@@ -225,13 +229,10 @@ class CimConverter:
                 fuse_buses(self.net, b1, b2, drop=True, fuse_bus_measurements=True)
         # finally a fix for EquivalentInjections: If an EquivalentInjection is attached to boundary node, check if the
         # network behind this boundary node is attached. In this case, disable the EquivalentInjection.
-        ward_t = self.net.ward.copy()
-        ward_t['bus_prf'] = ward_t['bus'].map(self.net.bus[[sc['o_prf']]].to_dict().get(sc['o_prf']))
-        self.net.ward.loc[(self.net.ward.bus.duplicated(keep=False) &
-                           ((ward_t['bus_prf'] == 'eq_bd') | (ward_t['bus_prf'] == 'tp_bd'))), 'in_service'] = False
-        xward_t = self.net.xward.copy()
-        xward_t['bus_prf'] = xward_t['bus'].map(self.net.bus[[sc['o_prf']]].to_dict().get(sc['o_prf']))
-        self.net.xward.loc[(self.net.xward.bus.duplicated(keep=False) &
-                            ((xward_t['bus_prf'] == 'eq_bd') | (xward_t['bus_prf'] == 'tp_bd'))), 'in_service'] = False
+        for w in ["ward", "xward"]:
+            w_t = self.net[w].copy()
+            w_t['bus_prf'] = w_t['bus'].map(self.net.bus[[sc['o_prf']]].to_dict().get(sc['o_prf']))
+            self.net[w].loc[(self.net[w].bus.duplicated(keep=False) &
+                             ((w_t['bus_prf'] == 'eq_bd') | (w_t['bus_prf'] == 'tp_bd'))), 'in_service'] = False
         self.net['report_container'] = self.report_container
         return self.net

--- a/pandapower/converter/cim/cim2pp/convert_measurements.py
+++ b/pandapower/converter/cim/cim2pp/convert_measurements.py
@@ -137,7 +137,7 @@ class CreateMeasurements:
         busses_temp = self.net.bus[['name', 'vn_kv', sc['ct']]].copy()
         busses_temp = busses_temp.reset_index(level=0)
         busses_temp = busses_temp.rename(columns={'index': 'element', sc['ct']: 'TopologicalNode'})
-        sv_sv_voltages = pd.merge(self.cim['sv']['SvVoltage'][['rdfId', 'TopologicalNode', 'v']], busses_temp,
+        sv_sv_voltages = pd.merge(self.cim['sv']['SvVoltage'][['rdfId', 'TopologicalNode', 'v', 'angle']], busses_temp,
                                   how='left', on='TopologicalNode')
         # drop all the rows mit vn_kv == np.nan (no measurements available for that bus)
         sv_sv_voltages = sv_sv_voltages.dropna(subset=['vn_kv'])
@@ -161,8 +161,15 @@ class CreateMeasurements:
         sv_sv_voltages[sc['desc']] = None
         sv_sv_voltages[sc['a_id']] = None
         sv_sv_voltages = sv_sv_voltages.rename(columns={'rdfId': sc['o_id']})
-
         self._copy_to_measurement(sv_sv_voltages)
+
+        # the angle
+        sv_sv_voltages_angle = sv_sv_voltages.copy()
+        sv_sv_voltages_angle['value'] = sv_sv_voltages_angle['angle']
+        sv_sv_voltages_angle['measurement_type'] = 'angle'
+        sv_sv_voltages_angle['std_dev'] = .001
+        self._copy_to_measurement(sv_sv_voltages_angle)
+
 
         # ---------------------------------------measure: line---------------------------------------------------
         sigma_line = 0.03

--- a/pandapower/converter/cim/cim2pp/converter_classes/connectivitynodes/connectivityNodesCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/connectivitynodes/connectivityNodesCim16.py
@@ -113,7 +113,7 @@ class ConnectivityNodesCim16:
 
             connectivity_nodes = pd.merge(connectivity_nodes, eq_voltage_levels, how='left',
                                           on='ConnectivityNodeContainer')
-            if 'tp_bd' in self.cimConverter.cim:
+            if self.cimConverter.cim_version == '2.4.15':
                 # now prepare the BaseVoltage from the boundary profile at the ConnectivityNode (4)
                 eq_bd_cns = pd.merge(self.cimConverter.cim['eq_bd']['ConnectivityNode'][['rdfId']],
                                      self.cimConverter.cim['tp_bd']['ConnectivityNode'][['rdfId', 'TopologicalNode']],
@@ -134,6 +134,20 @@ class ConnectivityNodesCim16:
             connectivity_nodes['BaseVoltage'] = connectivity_nodes['BaseVoltage'].fillna(
                 connectivity_nodes['BaseVoltage_2'])
             connectivity_nodes = connectivity_nodes.drop(columns=['BaseVoltage_2'])
+            # check if the version is LTDS: If so, some nodes might have no voltage given. In LTDS, the boundary nodes
+            # are part of the EQ profile without a reference to VoltageLevel. Get the voltage from the attached
+            # EquivalentInjection
+            if self.cimConverter.cim_version == 'ltds' and connectivity_nodes['BaseVoltage'].isna().any():
+                # create a mapping for the missing voltages
+                mapping = self.cimConverter.cim['eq']['EquivalentInjection'][['BaseVoltage', 'EquipmentContainer']]
+                mapping = mapping.set_index('EquipmentContainer').to_dict()['BaseVoltage']
+                connectivity_nodes.loc[connectivity_nodes['BaseVoltage'].isna(), 'BaseVoltage_2'] = (
+                    connectivity_nodes.loc[connectivity_nodes['BaseVoltage'].isna(),
+                    'ConnectivityNodeContainer'].map(mapping))
+                connectivity_nodes['BaseVoltage'] = connectivity_nodes['BaseVoltage'].fillna(
+                    connectivity_nodes['BaseVoltage_2'])
+                connectivity_nodes = connectivity_nodes.drop(columns=['BaseVoltage_2'])
+                del mapping
             # check if there is a mix between BB and NB models
             terminals_temp = \
                 self.cimConverter.cim['eq']['Terminal'].loc[
@@ -148,7 +162,7 @@ class ConnectivityNodesCim16:
                 tp_temp = self.cimConverter.cim['tp']['TopologicalNode'][
                     ['rdfId', 'name', 'description', 'BaseVoltage']]
                 tp_temp[sc['o_prf']] = 'tp'
-                if 'tp_bd' in self.cimConverter.cim:  # check because tp_bd has been removed in cgmes 3.0
+                if self.cimConverter.cim_version == '2.4.15':
                     tp_temp = pd.concat(
                         [tp_temp, self.cimConverter.cim['tp_bd']['TopologicalNode'][['rdfId', 'name', 'BaseVoltage']]],
                         sort=False)
@@ -188,6 +202,7 @@ class ConnectivityNodesCim16:
         connectivity_nodes['BaseVoltage'] = connectivity_nodes['BaseVoltage'].astype(str)
         connectivity_nodes = pd.merge(connectivity_nodes, eq_base_voltages, how='left', on='BaseVoltage')
         connectivity_nodes = connectivity_nodes.drop(columns=['BaseVoltage'])
+        # the terminals are used for the mapping asset -> node later during the conversion of other assets
         eqssh_terminals = self.cimConverter.cim['eq']['Terminal'][['rdfId', 'ConnectivityNode', 'ConductingEquipment',
                                                                    'sequenceNumber']]
         eqssh_terminals = \
@@ -278,6 +293,6 @@ class ConnectivityNodesCim16:
                                                                 'nominalVoltage': 'vn_kv', 'name_substation': 'zone'})
         connectivity_nodes['in_service'] = True
         # set if a bus is a busbar or a node
+        connectivity_nodes['type'] = 'n'
         connectivity_nodes.loc[connectivity_nodes[sc['bb_id']].notna(), 'type'] = 'b'
-        connectivity_nodes['type'] = connectivity_nodes['type'].fillna('n')
         return connectivity_nodes, eqssh_terminals

--- a/pandapower/converter/cim/cim2pp/converter_classes/externalnetworks/externalNetworkInjectionsCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/externalnetworks/externalNetworkInjectionsCim16.py
@@ -59,10 +59,10 @@ class ExternalNetworkInjectionsCim16:
                     (eni_slacks.index.size, eni_gens.index.size, eni_sgens.index.size, time.time() - time_start)))
 
     def _prepare_external_network_injections_cim16(self) -> pd.DataFrame:
-        if 'sc' in self.cimConverter.cim:
+        if 'sc' in self.cimConverter.cim:  # CGMES 3.0
             eni = self.cimConverter.merge_eq_other_profiles(['ssh', 'sc'], 'ExternalNetworkInjection',
                                                         add_cim_type_column=True)
-        else:
+        else:  # CGMES 2.4.25
             eni = self.cimConverter.merge_eq_ssh_profile('ExternalNetworkInjection', add_cim_type_column=True)
 
         # merge with buses
@@ -83,6 +83,9 @@ class ExternalNetworkInjectionsCim16:
         # ignore targetValues with mode != voltage
         eni.loc[eni['mode'] != 'voltage', 'vm_pu'] = np.nan
         eni['vm_pu'] = eni['vm_pu'].fillna(eni['v'] / eni['vn_kv'])  # voltage from measurement
+        if eni['vm_pu'].isna().any():
+            self.logger.warning(f"Missing target voltage for the following external network injections: "
+                                f"{eni.loc[eni['vm_pu'].isna(), self.sc['o_id']]}. Setting voltages to 1 pu.")
         eni['vm_pu'] = eni['vm_pu'].fillna(1.)  # default voltage
         eni['angle'] = eni['angle'].fillna(0.)  # default angle
         eni['ratedU'] = eni['targetValue'][:]  # targetValue in kV
@@ -90,21 +93,21 @@ class ExternalNetworkInjectionsCim16:
         eni['ratedU'] = eni['ratedU'].fillna(eni['vn_kv'])
         eni['s_sc_max_mva'] = 3 ** .5 * eni['ratedU'] * (eni['maxInitialSymShCCurrent'] / 1e3)
         eni['s_sc_min_mva'] = 3 ** .5 * eni['ratedU'] * (eni['minInitialSymShCCurrent'] / 1e3)
+        eni['x0x_max'] = ((eni['maxR1ToX1Ratio'] + 1j) /
+                          (eni['maxR0ToX0Ratio'] + 1j)).abs() * eni['maxZ0ToZ1Ratio']
         # get the substations
-        eni = pd.merge(eni,
-                       self.cimConverter.net.bus[[sc['o_id'], 'zone']].rename({sc['o_id']: 'b_id'}, axis=1),
+        eni = pd.merge(eni, self.cimConverter.net.bus[[sc['o_id'], 'zone']].rename({sc['o_id']: 'b_id'}, axis=1),
                        how='left', left_on='ConnectivityNode', right_on='b_id')
         
         eni['referencePriority'] = eni['referencePriority'].astype(float)
         eni['slack_weight'] = eni['referencePriority'][:]
         eni.loc[eni['slack_weight'] == 0, 'slack_weight'] = np.nan
         eni['RegulatingControl.mode'] = eni['mode'][:]
+        # toggle sign (load sign convention in CGMES)
         eni['p'] = -eni['p']
         eni['q'] = -eni['q']
-        eni['x0x_max'] = ((eni['maxR1ToX1Ratio'] + 1j) /
-                          (eni['maxR0ToX0Ratio'] + 1j)).abs() * eni['maxZ0ToZ1Ratio']
 
-        if 'inService' in eni.columns:
+        if 'inService' in eni.columns:  # CGMES 3.0
             eni['connected'] = eni['connected'] & eni['inService']
 
         eni = eni.rename(columns={'rdfId': sc['o_id'], 'rdfId_Terminal': sc['t'], 'zone': sc['sub'],

--- a/pandapower/converter/cim/cim2pp/converter_classes/generators/asynchronousMachinesCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/generators/asynchronousMachinesCim16.py
@@ -62,9 +62,10 @@ class AsynchronousMachinesCim16:
             asynchronous_machines = self.cimConverter.merge_eq_ssh_profile('AsynchronousMachine',
                                                                            add_cim_type_column=True)
         # prevent conflict of merging two dataframes each containing column 'name'
-        eqssh_generating_units = eqssh_generating_units.drop('name', axis=1)
+        eqssh_generating_units = eqssh_generating_units.drop(columns='name')
+        eqssh_generating_units = eqssh_generating_units.rename(columns={'inService': 'inService_gu'})
         asynchronous_machines = pd.merge(asynchronous_machines, eqssh_generating_units,
-                                         how='left', suffixes=('_x', '_y'), on='GeneratingUnit')
+                                         how='left', on='GeneratingUnit')
         asynchronous_machines = pd.merge(asynchronous_machines, self.cimConverter.bus_merge, how='left',
                                          on='rdfId')
         asynchronous_machines['p_mw'] = -asynchronous_machines['p']
@@ -76,16 +77,17 @@ class AsynchronousMachinesCim16:
         asynchronous_machines['generator_type'] = 'async'
         asynchronous_machines['loading_percent'] = \
             100 * asynchronous_machines['p_mw'] / asynchronous_machines['ratedMechanicalPower']
-        if 'inService_x' in asynchronous_machines.columns:
-            asynchronous_machines['connected'] = (asynchronous_machines['connected']
-                                                  & asynchronous_machines['inService_x']
-                                                  & asynchronous_machines['inService_y'])
-        asynchronous_machines = asynchronous_machines.rename(columns={'rdfId_Terminal': sc['t'], 'rdfId': sc['o_id'],
-                                                                      'connected': 'in_service', 'index_bus': 'bus',
-                                                                      'rxLockedRotorRatio': 'rx', 'iaIrRatio': 'lrc_pu',
-                                                                      'ratedPowerFactor': 'cos_phi', 'ratedU': 'vn_kv',
-                                                                      'efficiency': 'efficiency_n_percent',
-                                                                      'ratedMechanicalPower': 'pn_mech_mw'})
+        if self.cimConverter.cim_version == '3.0':
+            asynchronous_machines['in_service'] = (asynchronous_machines.connected & asynchronous_machines.inService &
+                                                   asynchronous_machines.inService_gu)
+        elif self.cimConverter.cim_version == 'ltds':
+            asynchronous_machines['in_service'] = asynchronous_machines.inService
+        else:
+            asynchronous_machines['in_service'] = asynchronous_machines.connected
+        asynchronous_machines = asynchronous_machines.rename(columns={
+            'rdfId_Terminal': sc['t'], 'rdfId': sc['o_id'], 'index_bus': 'bus', 'rxLockedRotorRatio': 'rx',
+            'iaIrRatio': 'lrc_pu', 'ratedPowerFactor': 'cos_phi', 'ratedU': 'vn_kv',
+            'efficiency': 'efficiency_n_percent', 'ratedMechanicalPower': 'pn_mech_mw'})
         asynchronous_machines['scaling'] = 1
         asynchronous_machines['efficiency_percent'] = 100
         return asynchronous_machines

--- a/pandapower/converter/cim/cim2pp/converter_classes/generators/energySourcesCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/generators/energySourcesCim16.py
@@ -24,9 +24,6 @@ class EnergySourceCim16:
         eqssh_energy_sources = self._prepare_energy_sources_cim16()
         es_slack = eqssh_energy_sources.loc[eqssh_energy_sources.vm_pu.notna()]
         es_sgen = eqssh_energy_sources.loc[eqssh_energy_sources.vm_pu.isna()]
-        # create reactive_capability_curve flag
-        if 'reactive_capability_curve' not in es_sgen.columns:
-            es_sgen['reactive_capability_curve'] = False
         self.cimConverter.copy_to_pp('ext_grid', es_slack)
         self.cimConverter.copy_to_pp('sgen', es_sgen)
         # self._copy_to_pp('sgen', eqssh_energy_sources)
@@ -60,9 +57,13 @@ class EnergySourceCim16:
         eqssh_energy_sources['current_source'] = True
         eqssh_energy_sources['generator_type'] = 'current_source'
         eqssh_energy_sources['controllable'] = False
-        if 'inService' in eqssh_energy_sources.columns:
-            eqssh_energy_sources['connected'] = (eqssh_energy_sources['connected']
-                                                 & eqssh_energy_sources['inService'])
+        eqssh_energy_sources['reactive_capability_curve'] = False
+        if self.cimConverter.cim_version == '3.0':
+           eqssh_energy_sources['in_service'] = eqssh_energy_sources.connected & eqssh_energy_sources.inService
+        elif self.cimConverter.cim_version == 'ltds':
+           eqssh_energy_sources['in_service'] = eqssh_energy_sources.inService
+        else:
+           eqssh_energy_sources['in_service'] = eqssh_energy_sources.connected
         eqssh_energy_sources = eqssh_energy_sources.rename(columns={'rdfId_Terminal': sc['t'], 'rdfId': sc['o_id'],
-                                                                    'connected': 'in_service', 'index_bus': 'bus'})
+                                                                    'index_bus': 'bus'})
         return eqssh_energy_sources

--- a/pandapower/converter/cim/cim2pp/converter_classes/generators/synchronousMachinesCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/generators/synchronousMachinesCim16.py
@@ -130,9 +130,9 @@ class SynchronousMachinesCim16:
         synchronous_machines['current_source'] = True
         synchronous_machines['sn_mva'] = \
             synchronous_machines['ratedS'].fillna(synchronous_machines['nominalP'])
-        # Convert governorSCD unit from percent to MW/Hz
+        # Convert governorSCD unit from percent to MW/Hz, used for distributed slack
         synchronous_machines['governorSCD'] = synchronous_machines['governorSCD'] * synchronous_machines[
-            'nominalP'] / 50 / 100
+            'nominalP'] / self.cimConverter.net['f_hz'] / 100
         # SC data
         synchronous_machines['vn_kv'] = synchronous_machines['ratedU'][:]
         synchronous_machines['rdss_ohm'] = \
@@ -152,10 +152,14 @@ class SynchronousMachinesCim16:
         synchronous_machines.loc[synchronous_machines['slack_weight'] == 0, 'slack_weight'] = np.nan
         synchronous_machines['RegulatingControl.enabled'] = synchronous_machines['enabled'][:]
         synchronous_machines['RegulatingControl.mode'] = synchronous_machines['mode'][:]
-        if 'inService' in synchronous_machines.columns:
-            synchronous_machines['connected'] = (synchronous_machines['connected'] & synchronous_machines['inService'])
+        if self.cimConverter.cim_version == '3.0':
+           synchronous_machines['in_service'] = synchronous_machines.connected & synchronous_machines.inService
+        elif self.cimConverter.cim_version == 'ltds':
+           synchronous_machines['in_service'] = synchronous_machines.inService
+        else:
+           synchronous_machines['in_service'] = synchronous_machines.connected
         synchronous_machines = synchronous_machines.rename(columns={
-            'rdfId_Terminal': sc['t'], 'rdfId': sc['o_id'], 'connected': 'in_service', 'index_bus': 'bus',
+            'rdfId_Terminal': sc['t'], 'rdfId': sc['o_id'], 'index_bus': 'bus',
             'minOperatingP': 'min_p_mw', 'maxOperatingP': 'max_p_mw', 'minQ': 'min_q_mvar', 'maxQ': 'max_q_mvar',
             'ratedPowerFactor': 'cos_phi', 'targetValue': 'RegulatingControl.targetValue'})
         return synchronous_machines

--- a/pandapower/converter/cim/cim2pp/converter_classes/impedance/equivalentBranchesCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/impedance/equivalentBranchesCim16.py
@@ -111,7 +111,14 @@ class EquivalentBranchesCim16:
         eqb['bf_pu'] = 0.
         eqb['gt_pu'] = 0.
         eqb['bt_pu'] = 0.
-        eqb['in_service'] = eqb.connected & eqb.connected2
+        if self.cimConverter.cim_version == '3.0':
+           eqb['in_service'] = eqb.connected & eqb.connected2 & eqb.inService
+        elif self.cimConverter.cim_version == 'ltds':
+            mapping = self.cimConverter.cim['ssh']['Equipment'][['rdfId', 'inService']]
+            mapping = mapping.set_index('rdfId').to_dict()['inService']
+            eqb['in_service'] = eqb['rdfId'].map(mapping)
+        else:
+           eqb['in_service'] = eqb.connected & eqb.connected2
         eqb = eqb.rename(columns={'rdfId_Terminal': sc['t_from'], 'rdfId_Terminal2': sc['t_to'], 'rdfId': sc['o_id'],
                                   'index_bus': 'from_bus', 'index_bus2': 'to_bus'})
         return eqb

--- a/pandapower/converter/cim/cim2pp/converter_classes/lines/acLineSegmentsCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/lines/acLineSegmentsCim16.py
@@ -31,20 +31,6 @@ class AcLineSegmentsCim16:
                 'rdfId': sc['o_id'], 'rdfId_Terminal': sc['t_from'], 'rdfId_Terminal2': sc['t_to'],
                 'index_bus': 'from_bus', 'index_bus2': 'to_bus', 'length': 'length_km',
                 'shortCircuitEndTemperature': 'endtemp_degree', 'EquipmentContainer': 'EquipmentContainer_id'})
-            line_df[sc['o_cl']] = 'ACLineSegment'
-            line_df['in_service'] = line_df.connected & line_df.connected2
-            line_df['r_ohm_per_km'] = abs(line_df.r) / line_df.length_km
-            line_df['x_ohm_per_km'] = abs(line_df.x) / line_df.length_km
-            line_df['c_nf_per_km'] = abs(line_df.bch) / (2 * 50 * np.pi * line_df.length_km) * 1e9
-            line_df['g_us_per_km'] = abs(line_df.gch) * 1e6 / line_df.length_km
-            line_df['r0_ohm_per_km'] = abs(line_df.r0) / line_df.length_km
-            line_df['x0_ohm_per_km'] = abs(line_df.x0) / line_df.length_km
-            line_df['c0_nf_per_km'] = abs(line_df.b0ch) / (2 * 50 * np.pi * line_df.length_km) * 1e9
-            line_df['g0_us_per_km'] = abs(line_df.g0ch) * 1e6 / line_df.length_km
-            line_df['parallel'] = 1
-            line_df['df'] = 1.
-            line_df['type'] = None
-            line_df['std_type'] = None
             self.cimConverter.copy_to_pp('line', line_df)
         else:
             line_df = pd.DataFrame(None)
@@ -55,11 +41,6 @@ class AcLineSegmentsCim16:
             switch_df = switch_df.rename(columns={
                 'rdfId': sc['o_id'], 'index_bus': 'bus', 'index_bus2': 'element', 'rdfId_Terminal': sc['t_bus'],
                 'rdfId_Terminal2': sc['t_ele']})
-            switch_df['et'] = 'b'
-            switch_df['type'] = None
-            switch_df['z_ohm'] = 0
-            if switch_df.index.size > 0:
-                switch_df['closed'] = switch_df.connected & switch_df.connected2
             self.cimConverter.copy_to_pp('switch', switch_df)
         else:
             switch_df = pd.DataFrame(None)
@@ -73,9 +54,9 @@ class AcLineSegmentsCim16:
 
     def _prepare_ac_line_segments_cim16(self, convert_line_to_switch, line_r_limit, line_x_limit) -> pd.DataFrame:
 
-        if 'sc' in self.cimConverter.cim:
+        if 'sc' in self.cimConverter.cim:  # CGMES 3.0
             ac_line_segments = self.cimConverter.merge_eq_sc_profile('ACLineSegment')
-        else:
+        else:  # CGMES 2.4.15
             ac_line_segments = self.cimConverter.cim['eq']['ACLineSegment']
 
         line_length_before_merge = ac_line_segments.index.size
@@ -84,8 +65,7 @@ class AcLineSegmentsCim16:
         #   _x01    line1   0.056   ...
         #   _x02    line2   0.471   ...
         # now join with the terminals
-        ac_line_segments = pd.merge(ac_line_segments, self.cimConverter.bus_merge,
-                                       how='left', on='rdfId')
+        ac_line_segments = pd.merge(ac_line_segments, self.cimConverter.bus_merge, how='left', on='rdfId')
         ac_line_segments[sc['o_cl']] = 'ACLineSegment'
         # now ac_line_segments looks like:
         #   rdfId   name    r       rdfId_Terminal  connected   ...
@@ -124,10 +104,10 @@ class AcLineSegmentsCim16:
                                                   'Terminal': 'rdfId_Terminal'})
         ac_line_segments = pd.merge(ac_line_segments, eq_operational_limit_sets, how='left',
                                        on='rdfId_Terminal')
-        if 'CurrentLimit' in self.cimConverter.cim['ssh']:
+        if 'CurrentLimit' in self.cimConverter.cim['ssh']:  # CGMES 3.0
             current_limits = self.cimConverter.merge_eq_ssh_profile('CurrentLimit')[['rdfId', 'OperationalLimitSet',
                                                                                      'value']]
-        else:
+        else:  # CGMES 2.4.15
             current_limits = self.cimConverter.cim['eq']['CurrentLimit'][['rdfId', 'OperationalLimitSet', 'value']]
         current_limits = current_limits.rename(columns={'rdfId': 'rdfId_CurrentLimit',
                                           'OperationalLimitSet': 'rdfId_OperationalLimitSet'})
@@ -155,10 +135,38 @@ class AcLineSegmentsCim16:
         ac_line_segments = ac_line_segments.drop_duplicates(['rdfId'], keep='first')
         # get the max_i_ka
         ac_line_segments['max_i_ka'] = ac_line_segments['value'].fillna(ac_line_segments['value2']) * 1e-3
+        if self.cimConverter.cim_version == '3.0':
+           ac_line_segments['in_service'] = (ac_line_segments.connected & ac_line_segments.connected2 &
+                                             ac_line_segments.inService)
+        elif self.cimConverter.cim_version == 'ltds':
+            mapping = self.cimConverter.cim['ssh']['Equipment'][['rdfId', 'inService']]
+            mapping = mapping.set_index('rdfId').to_dict()['inService']
+            ac_line_segments['in_service'] = ac_line_segments['rdfId'].map(mapping)
+        else:
+            ac_line_segments['in_service'] = ac_line_segments.connected & ac_line_segments.connected2
+        ac_line_segments['closed'] = ac_line_segments['in_service']
 
         # filter if line or switches will be added
         ac_line_segments['kindOfType'] = 'line'
         if convert_line_to_switch:
             ac_line_segments.loc[(abs(ac_line_segments['r']) <= line_r_limit) |
                                     (abs(ac_line_segments['x']) <= line_x_limit), 'kindOfType'] = 'switch'
+        ac_line_segments[sc['o_cl']] = 'ACLineSegment'
+        ac_line_segments['r_ohm_per_km'] = abs(ac_line_segments.r) / ac_line_segments.length
+        ac_line_segments['x_ohm_per_km'] = abs(ac_line_segments.x) / ac_line_segments.length
+        ac_line_segments['c_nf_per_km'] = abs(ac_line_segments.bch) / (2 * 50 * np.pi * ac_line_segments.length) * 1e9
+        ac_line_segments['g_us_per_km'] = abs(ac_line_segments.gch) * 1e6 / ac_line_segments.length
+        ac_line_segments['r0_ohm_per_km'] = abs(ac_line_segments.r0) / ac_line_segments.length
+        ac_line_segments['x0_ohm_per_km'] = abs(ac_line_segments.x0) / ac_line_segments.length
+        ac_line_segments['c0_nf_per_km'] = abs(ac_line_segments.b0ch) / (2 * 50 * np.pi * ac_line_segments.length) * 1e9
+        ac_line_segments['g0_us_per_km'] = abs(ac_line_segments.g0ch) * 1e6 / ac_line_segments.length
+        ac_line_segments['parallel'] = 1
+        ac_line_segments['df'] = 1.
+        ac_line_segments['type'] = None
+        ac_line_segments['std_type'] = None
+        ac_line_segments['et'] = 'b'
+        if self.cimConverter.kwargs.get('set_switch_impedance', False):
+            ac_line_segments['z_ohm'] = (abs(ac_line_segments.r)**2 + abs(ac_line_segments.x)**2)**.5
+        else:
+            ac_line_segments['z_ohm'] = 0
         return ac_line_segments

--- a/pandapower/converter/cim/cim2pp/converter_classes/lines/dcLineSegmentsCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/lines/dcLineSegmentsCim16.py
@@ -141,10 +141,15 @@ class DcLineSegmentsCim16:
         dc_line_segments['loss_percent'] = 0
         dc_line_segments['vm_from_pu'] = dc_line_segments['targetUpcc'] / dc_line_segments['base_voltage_bus']
         dc_line_segments['vm_to_pu'] = dc_line_segments['targetUpcc2'] / dc_line_segments['base_voltage_bus2']
-        if 'inService' not in dc_line_segments.columns:
-            dc_line_segments['inService'] = True
-        dc_line_segments['in_service'] = (dc_line_segments.connected & dc_line_segments.connected2
-                                          & dc_line_segments.inService)
+        if self.cimConverter.cim_version == '3.0':
+           dc_line_segments['in_service'] = (dc_line_segments.connected & dc_line_segments.connected2 &
+                                             dc_line_segments.inService)
+        elif self.cimConverter.cim_version == 'ltds':
+            mapping = self.cimConverter.cim['ssh']['Equipment'][['rdfId', 'inService']]
+            mapping = mapping.set_index('rdfId').to_dict()['inService']
+            dc_line_segments['in_service'] = dc_line_segments['rdfId'].map(mapping)
+        else:
+            dc_line_segments['in_service'] = dc_line_segments.connected & dc_line_segments.connected2
         dc_line_segments = dc_line_segments.rename(columns={
             'rdfId': sc['o_id'], 'rdfId_Terminal': sc['t_from'], 'rdfId_Terminal2': sc['t_to'], 'index_bus': 'from_bus',
             'index_bus2': 'to_bus'})

--- a/pandapower/converter/cim/cim2pp/converter_classes/loads/conformLoadsCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/loads/conformLoadsCim16.py
@@ -31,10 +31,14 @@ class ConformLoadsCim16:
     def _prepare_conform_loads_cim16(self) -> pd.DataFrame:
         eqssh_conform_loads = self.cimConverter.merge_eq_ssh_profile('ConformLoad', add_cim_type_column=True)
         eqssh_conform_loads = pd.merge(eqssh_conform_loads, self.cimConverter.bus_merge, how='left', on='rdfId')
-        if 'inService' in eqssh_conform_loads.columns:
-            eqssh_conform_loads['connected'] = eqssh_conform_loads['connected'] & eqssh_conform_loads['inService']
-        eqssh_conform_loads = eqssh_conform_loads.rename(columns={'rdfId': sc['o_id'], 'rdfId_Terminal': sc['t'], 'index_bus': 'bus',
-                                            'connected': 'in_service', 'p': 'p_mw', 'q': 'q_mvar'})
+        if self.cimConverter.cim_version == '3.0':
+           eqssh_conform_loads['in_service'] = eqssh_conform_loads.connected & eqssh_conform_loads.inService
+        elif self.cimConverter.cim_version == 'ltds':
+           eqssh_conform_loads['in_service'] = eqssh_conform_loads.inService
+        else:
+           eqssh_conform_loads['in_service'] = eqssh_conform_loads.connected
+        eqssh_conform_loads = eqssh_conform_loads.rename(columns={'rdfId': sc['o_id'], 'rdfId_Terminal': sc['t'],
+                                                                  'index_bus': 'bus', 'p': 'p_mw', 'q': 'q_mvar'})
         eqssh_conform_loads['const_i_p_percent'] = 0.
         eqssh_conform_loads['const_z_p_percent'] = 0.
         eqssh_conform_loads['const_i_q_percent'] = 0.

--- a/pandapower/converter/cim/cim2pp/converter_classes/loads/energyConsumersCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/loads/energyConsumersCim16.py
@@ -31,10 +31,14 @@ class EnergyConsumersCim16:
     def _prepare_energy_consumers_cim16(self) -> pd.DataFrame:
         eqssh_energy_consumers = self.cimConverter.merge_eq_ssh_profile('EnergyConsumer', add_cim_type_column=True)
         eqssh_energy_consumers = pd.merge(eqssh_energy_consumers, self.cimConverter.bus_merge, how='left', on='rdfId')
-        if 'inService' in eqssh_energy_consumers.columns:
-            eqssh_energy_consumers['connected'] = eqssh_energy_consumers['connected'] & eqssh_energy_consumers['inService']
-        eqssh_energy_consumers = eqssh_energy_consumers.rename(columns={'rdfId': sc['o_id'], 'rdfId_Terminal': sc['t'], 'index_bus': 'bus',
-                                               'connected': 'in_service', 'p': 'p_mw', 'q': 'q_mvar'})
+        if self.cimConverter.cim_version == '3.0':
+           eqssh_energy_consumers['in_service'] = eqssh_energy_consumers.connected & eqssh_energy_consumers.inService
+        elif self.cimConverter.cim_version == 'ltds':
+           eqssh_energy_consumers['in_service'] = eqssh_energy_consumers.inService
+        else:
+           eqssh_energy_consumers['in_service'] = eqssh_energy_consumers.connected
+        eqssh_energy_consumers = eqssh_energy_consumers.rename(columns={'rdfId': sc['o_id'], 'rdfId_Terminal': sc['t'],
+                                                                        'index_bus': 'bus', 'p': 'p_mw', 'q': 'q_mvar'})
         eqssh_energy_consumers['const_i_p_percent'] = 0.
         eqssh_energy_consumers['const_z_p_percent'] = 0.
         eqssh_energy_consumers['const_i_q_percent'] = 0.

--- a/pandapower/converter/cim/cim2pp/converter_classes/loads/nonConformLoadsCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/loads/nonConformLoadsCim16.py
@@ -31,10 +31,14 @@ class NonConformLoadsCim16:
     def _prepare_non_conform_loads_cim16(self) -> pd.DataFrame:
         eqssh_non_conform_loads = self.cimConverter.merge_eq_ssh_profile('NonConformLoad', add_cim_type_column=True)
         eqssh_non_conform_loads = pd.merge(eqssh_non_conform_loads, self.cimConverter.bus_merge, how='left', on='rdfId')
-        if 'inService' in eqssh_non_conform_loads.columns:
-            eqssh_non_conform_loads['connected'] = eqssh_non_conform_loads['connected'] & eqssh_non_conform_loads['inService']
-        eqssh_non_conform_loads = eqssh_non_conform_loads.rename(columns={'rdfId': sc['o_id'], 'rdfId_Terminal': sc['t'], 'index_bus': 'bus',
-                                                'connected': 'in_service', 'p': 'p_mw', 'q': 'q_mvar'})
+        if self.cimConverter.cim_version == '3.0':
+           eqssh_non_conform_loads['in_service'] = eqssh_non_conform_loads.connected & eqssh_non_conform_loads.inService
+        elif self.cimConverter.cim_version == 'ltds':
+           eqssh_non_conform_loads['in_service'] = eqssh_non_conform_loads.inService
+        else:
+           eqssh_non_conform_loads['in_service'] = eqssh_non_conform_loads.connected
+        eqssh_non_conform_loads = eqssh_non_conform_loads.rename(columns={
+            'rdfId': sc['o_id'], 'rdfId_Terminal': sc['t'], 'index_bus': 'bus', 'p': 'p_mw', 'q': 'q_mvar'})
         eqssh_non_conform_loads['const_i_p_percent'] = 0.
         eqssh_non_conform_loads['const_z_p_percent'] = 0.
         eqssh_non_conform_loads['const_i_q_percent'] = 0.

--- a/pandapower/converter/cim/cim2pp/converter_classes/loads/stationSuppliesCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/loads/stationSuppliesCim16.py
@@ -31,10 +31,14 @@ class StationSuppliesCim16:
     def _prepare_station_supplies_cim16(self) -> pd.DataFrame:
         eqssh_station_supplies = self.cimConverter.merge_eq_ssh_profile('StationSupply', add_cim_type_column=True)
         eqssh_station_supplies = pd.merge(eqssh_station_supplies, self.cimConverter.bus_merge, how='left', on='rdfId')
-        if 'inService' in eqssh_station_supplies.columns:
-            eqssh_station_supplies['connected'] = eqssh_station_supplies['connected'] & eqssh_station_supplies['inService']
-        eqssh_station_supplies = eqssh_station_supplies.rename(columns={'rdfId': sc['o_id'], 'rdfId_Terminal': sc['t'], 'index_bus': 'bus',
-                                               'connected': 'in_service', 'p': 'p_mw', 'q': 'q_mvar'})
+        if self.cimConverter.cim_version == '3.0':
+           eqssh_station_supplies['in_service'] = eqssh_station_supplies.connected & eqssh_station_supplies.inService
+        elif self.cimConverter.cim_version == 'ltds':
+           eqssh_station_supplies['in_service'] = eqssh_station_supplies.inService
+        else:
+           eqssh_station_supplies['in_service'] = eqssh_station_supplies.connected
+        eqssh_station_supplies = eqssh_station_supplies.rename(columns={'rdfId': sc['o_id'], 'rdfId_Terminal': sc['t'],
+                                                                        'index_bus': 'bus', 'p': 'p_mw', 'q': 'q_mvar'})
         eqssh_station_supplies['const_i_p_percent'] = 0.
         eqssh_station_supplies['const_z_p_percent'] = 0.
         eqssh_station_supplies['const_i_q_percent'] = 0.

--- a/pandapower/converter/cim/cim2pp/converter_classes/shunts/linearShuntCompensatorCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/shunts/linearShuntCompensatorCim16.py
@@ -32,11 +32,15 @@ class LinearShuntCompensatorCim16:
     def _prepare_linear_shunt_compensator_cim16(self) -> pd.DataFrame:
         eqssh_shunts = self.cimConverter.merge_eq_ssh_profile('LinearShuntCompensator', add_cim_type_column=True)
         eqssh_shunts = pd.merge(eqssh_shunts, self.cimConverter.bus_merge, how='left', on='rdfId')
-        if 'inService' in eqssh_shunts.columns:
-            eqssh_shunts['connected'] = eqssh_shunts['connected'] & eqssh_shunts['inService']
+        if self.cimConverter.cim_version == '3.0':
+           eqssh_shunts['in_service'] = eqssh_shunts.connected & eqssh_shunts.inService
+        elif self.cimConverter.cim_version == 'ltds':
+           eqssh_shunts['in_service'] = eqssh_shunts.inService
+        else:
+           eqssh_shunts['in_service'] = eqssh_shunts.connected
         eqssh_shunts = eqssh_shunts.rename(columns={
-            'rdfId': sc['o_id'], 'rdfId_Terminal': sc['t'], 'connected': 'in_service', 'index_bus': 'bus',
-            'nomU': 'vn_kv', 'sections': 'step', 'maximumSections': 'max_step'})
+            'rdfId': sc['o_id'], 'rdfId_Terminal': sc['t'], 'index_bus': 'bus', 'nomU': 'vn_kv', 'sections': 'step',
+            'maximumSections': 'max_step'})
         # complex conductance
         y = eqssh_shunts['gPerSection'] + eqssh_shunts['bPerSection'] * 1j
         # apparent power

--- a/pandapower/converter/cim/cim2pp/converter_classes/shunts/nonLinearShuntCompensatorCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/shunts/nonLinearShuntCompensatorCim16.py
@@ -60,15 +60,19 @@ class NonLinearShuntCompensatorCim16:
                 eqssh_shunts.loc[eqssh_shunts['sections'] >= eqssh_shunts['sectionNumber'], 'q'] = \
                     eqssh_shunts['q'] + eqssh_shunts['q_temp']
             eqssh_shunts = eqssh_shunts[eqssh_shunts_cols]
-        if 'inService' in eqssh_shunts.columns:
-            eqssh_shunts['connected'] = eqssh_shunts['connected'] & eqssh_shunts['inService']
+        if self.cimConverter.cim_version == '3.0':
+           eqssh_shunts['in_service'] = eqssh_shunts.connected & eqssh_shunts.inService
+        elif self.cimConverter.cim_version == 'ltds':
+           eqssh_shunts['in_service'] = eqssh_shunts.inService
+        else:
+           eqssh_shunts['in_service'] = eqssh_shunts.connected
         # added to use the logic of p/q values multiplied by the number of steps
         # this is only correct for the current step values
         eqssh_shunts['p'] = eqssh_shunts['p'] / eqssh_shunts['sections']
         eqssh_shunts['q'] = eqssh_shunts['q'] / eqssh_shunts['sections']
         eqssh_shunts = eqssh_shunts.rename(columns={
-            'rdfId': sc['o_id'], 'rdfId_Terminal': sc['t'], 'connected': 'in_service', 'index_bus': 'bus',
-            'nomU': 'vn_kv', 'p': 'p_mw', 'q': 'q_mvar', 'sections': 'step', 'maximumSections': 'max_step'})
+            'rdfId': sc['o_id'], 'rdfId_Terminal': sc['t'], 'index_bus': 'bus', 'nomU': 'vn_kv', 'p': 'p_mw',
+            'q': 'q_mvar', 'sections': 'step', 'maximumSections': 'max_step'})
         return eqssh_shunts
 
     def _create_shunt_characteristic_table(self, eqssh_shunts):

--- a/pandapower/converter/cim/cim2pp/converter_classes/shunts/staticVarCompensatorCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/shunts/staticVarCompensatorCim16.py
@@ -36,13 +36,15 @@ class StaticVarCompensatorCim16:
         # therefore p is set to 0
         eq_stat_coms['p_mw'] = 0.0
         eq_stat_coms.loc[eq_stat_coms['sVCControlMode'] == 'reactivePower', 'voltageSetPoint'] = float('NaN')
-        if 'inService' in eq_stat_coms.columns:
-            eq_stat_coms['connected'] = eq_stat_coms['connected'] & eq_stat_coms['inService']
+        if self.cimConverter.cim_version == '3.0':
+           eq_stat_coms['in_service'] = eq_stat_coms.connected & eq_stat_coms.inService
+        elif self.cimConverter.cim_version == 'ltds':
+           eq_stat_coms['in_service'] = eq_stat_coms.inService
+        else:
+           eq_stat_coms['in_service'] = eq_stat_coms.connected
         eq_stat_coms = eq_stat_coms.rename(columns={'rdfId_Terminal': sc['t'], 'rdfId': sc['o_id'], 
-                                                    'voltageSetPoint': 'vn_kv', 'index_bus': 'bus', 'connected': 'in_service'})
+                                                    'voltageSetPoint': 'vn_kv', 'index_bus': 'bus'})
         eq_stat_coms['step'] = 1
         eq_stat_coms['max_step'] = 1
-        # create step_dependency_table flag
-        if 'step_dependency_table' not in eq_stat_coms.columns:
-            eq_stat_coms["step_dependency_table"] = False
+        eq_stat_coms["step_dependency_table"] = False
         return eq_stat_coms

--- a/pandapower/converter/cim/cim2pp/converter_classes/switches/switchesCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/switches/switchesCim16.py
@@ -81,9 +81,11 @@ class SwitchesCim16:
                                        'rdfId_Terminal': sc['t_bus'], 'rdfId_Terminal2': sc['t_ele']})
         eqssh_switches['et'] = 'b'
         eqssh_switches['z_ohm'] = 0
-        if 'inService' not in eqssh_switches.columns:
-            eqssh_switches['inService'] = True
-        if eqssh_switches.index.size > 0:
-            eqssh_switches['closed'] = (~eqssh_switches.open & eqssh_switches.connected & eqssh_switches.connected2
-                                        & eqssh_switches.inService)
+        if self.cimConverter.cim_version == '3.0' and eqssh_switches.index.size > 0:
+           eqssh_switches['closed'] = (~eqssh_switches.open & eqssh_switches.connected & eqssh_switches.connected2
+                                       & eqssh_switches.inService)
+        elif self.cimConverter.cim_version == 'ltds' and eqssh_switches.index.size > 0:
+           eqssh_switches['closed'] = (~eqssh_switches.open & eqssh_switches.inService)
+        elif eqssh_switches.index.size > 0:
+           eqssh_switches['closed'] = (~eqssh_switches.open & eqssh_switches.connected & eqssh_switches.connected2)
         return eqssh_switches

--- a/pandapower/converter/cim/cim2pp/converter_classes/transformers/powerTransformersCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/transformers/powerTransformersCim16.py
@@ -289,7 +289,11 @@ class PowerTransformersCim16:
             power_transformers = self.cimConverter.merge_eq_sc_profile('PowerTransformer')
         else:
             power_transformers = self.cimConverter.cim['eq']['PowerTransformer']
-        power_transformers = power_transformers[['rdfId', 'name', 'description', 'isPartOfGeneratorUnit']]
+        if self.cimConverter.cim_version == 'ltds':
+            power_transformers = power_transformers[['rdfId', 'name', 'description', 'isPartOfGeneratorUnit',
+                                                     'inService']]
+        else:
+            power_transformers = power_transformers[['rdfId', 'name', 'description', 'isPartOfGeneratorUnit']]
         power_transformers[sc['o_cl']] = 'PowerTransformer'
 
         if 'sc' in self.cimConverter.cim:
@@ -309,7 +313,7 @@ class PowerTransformersCim16:
         current_limits = current_limits.rename(columns={'OperationalLimitSet': 'rdfId'})
         current_limits = pd.merge(current_limits,
                                   self.cimConverter.cim['eq']['OperationalLimitSet'][['rdfId', 'Terminal']],
-                                  how='left', on='rdfId', validate='m:1')
+                                  how='left', on='rdfId', validate='m:m')  # should be validate='m:1'
         current_limits = current_limits.drop(columns='rdfId')
         current_limits = current_limits.rename(columns={'OperationalLimitType': 'rdfId'})
         if 'kind' in self.cimConverter.cim['eq']['OperationalLimitType']:  # CGMES 3.0
@@ -317,13 +321,13 @@ class PowerTransformersCim16:
                    .rename(columns={'kind': 'limitType'}))
         else:  # CGMES 2.4.15
             olt = self.cimConverter.cim['eq']['OperationalLimitType'][['rdfId', 'limitType', 'acceptableDuration']]
-        current_limits = pd.merge(current_limits, olt, how='left', on='rdfId', validate='m:1')
+        current_limits = pd.merge(current_limits, olt, how='left', on='rdfId', validate='m:m')  # should be validate=m:1
         current_limits = current_limits.drop(columns='rdfId')
         current_limits = current_limits.rename(columns={
             'value': 'CurrentLimit.value', 'limitType': 'OperationalLimitType.limitType',
             'acceptableDuration': 'OperationalLimitType.acceptableDuration'})
         power_transformer_ends = pd.merge(power_transformer_ends, current_limits, how='left', on='Terminal',
-                                          validate='1:m')
+                                          validate='m:m')  # should be validate='1:m'
         # make sure there is only one CurrentLimit per winding, keep the one with the lowest value (and choose patl
         # first: sort ascending for OperationalLimitType.limitType)
         power_transformer_ends = (
@@ -340,16 +344,16 @@ class PowerTransformersCim16:
         eqssh_tap_changers[sc['tc']] = 'RatioTapChanger'
         eqssh_tap_changers['tap_changer_type'] = "Ratio"  # Ratio/Asymmetrical phase shifter
         eqssh_tap_changers[sc['tc_id']] = eqssh_tap_changers['rdfId'].copy()
-        # todo: check correct implementation for PhaseTapChangerLinear tap changers
+        # todo: check correct implementation for PhaseTapChangerLinear tap changers -> Done and compared with PF
         eqssh_tap_changers_linear = pd.merge(self.cimConverter.cim['eq']['PhaseTapChangerLinear'],
                                              self.cimConverter.cim['ssh']['PhaseTapChangerLinear'], how='left',
                                              on='rdfId')
-        eqssh_tap_changers_linear['stepVoltageIncrement'] = .001
+        eqssh_tap_changers_linear['stepVoltageIncrement'] = np.nan
         eqssh_tap_changers_linear[sc['tc']] = 'PhaseTapChangerLinear'
         eqssh_tap_changers_linear['tap_changer_type'] = "Ideal"  # Ideal phase shifter
         eqssh_tap_changers_linear[sc['tc_id']] = eqssh_tap_changers_linear['rdfId'].copy()
         eqssh_tap_changers = pd.concat([eqssh_tap_changers, eqssh_tap_changers_linear], ignore_index=True, sort=False)
-        # todo: check correct implementation for PhaseTapChangerAsymmetrical tap changers
+        # todo: check correct implementation for PhaseTapChangerAsymmetrical tap changers -> Done and compared with PF
         eqssh_tap_changers_async = pd.merge(self.cimConverter.cim['eq']['PhaseTapChangerAsymmetrical'],
                                             self.cimConverter.cim['ssh']['PhaseTapChangerAsymmetrical'], how='left',
                                             on='rdfId')
@@ -366,6 +370,8 @@ class PowerTransformersCim16:
                                                  on='rdfId')
         eqssh_ratio_tap_changers_sync['stepVoltageIncrement'] = eqssh_ratio_tap_changers_sync['voltageStepIncrement']
         eqssh_ratio_tap_changers_sync = eqssh_ratio_tap_changers_sync.drop(columns=['voltageStepIncrement'])
+        eqssh_ratio_tap_changers_sync['stepPhaseShiftIncrement'] = (
+            eqssh_ratio_tap_changers_sync["stepVoltageIncrement"].apply(lambda du: 2 * math.atan2(du, 2)))
         eqssh_ratio_tap_changers_sync[sc['tc']] = 'PhaseTapChangerSymmetrical'
         eqssh_ratio_tap_changers_sync['tap_changer_type'] = "Symmetrical"  # Symmetrical phase shifter
         eqssh_ratio_tap_changers_sync[sc['tc_id']] = eqssh_ratio_tap_changers_sync['rdfId'].copy()
@@ -548,7 +554,10 @@ class PowerTransformersCim16:
         power_trafo2w['shift_degree'] = power_trafo2w['phaseAngleClock'].astype(float).fillna(
             power_trafo2w['phaseAngleClock_lv'].astype(float)) * 30
         power_trafo2w['parallel'] = 1
-        power_trafo2w['in_service'] = power_trafo2w.connected & power_trafo2w.connected_lv
+        if self.cimConverter.cim_version == 'ltds':
+            power_trafo2w['in_service'] = power_trafo2w.inService
+        else:
+            power_trafo2w['in_service'] = power_trafo2w.connected & power_trafo2w.connected_lv
         power_trafo2w['connectionKind'] = power_trafo2w['connectionKind'].fillna('')
         power_trafo2w['connectionKind_lv'] = power_trafo2w['connectionKind_lv'].fillna('')
         power_trafo2w['grounded'] = power_trafo2w['grounded'].fillna(True)
@@ -678,7 +687,11 @@ class PowerTransformersCim16:
         power_trafo3w['shift_mv_degree'] = power_trafo3w['phaseAngleClock_mv'].astype(float) * 30
         power_trafo3w['shift_lv_degree'] = power_trafo3w['phaseAngleClock_lv'].astype(float) * 30
         power_trafo3w['tap_at_star_point'] = False
-        power_trafo3w['in_service'] = power_trafo3w.connected & power_trafo3w.connected_mv & power_trafo3w.connected_lv
+        if self.cimConverter.cim_version == 'ltds':
+            power_trafo3w['in_service'] = power_trafo3w.inService
+        else:
+            power_trafo3w['in_service'] = (power_trafo3w.connected & power_trafo3w.connected_mv &
+                                           power_trafo3w.connected_lv)
         power_trafo3w['connectionKind'] = power_trafo3w['connectionKind'].fillna('')
         power_trafo3w['connectionKind_mv'] = power_trafo3w['connectionKind_mv'].fillna('')
         power_trafo3w['connectionKind_lv'] = power_trafo3w['connectionKind_lv'].fillna('')

--- a/pandapower/converter/cim/cim2pp/converter_classes/wards/equivalentInjectionsCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/wards/equivalentInjectionsCim16.py
@@ -53,11 +53,14 @@ class EquivalentInjectionsCim16:
         equivalent_injection.nominalVoltage = equivalent_injection.nominalVoltage.fillna(equivalent_injection.vn_kv)
         equivalent_injection['regulationStatus'] = equivalent_injection['regulationStatus'].fillna(False)
         equivalent_injection['vm_pu'] = equivalent_injection.regulationTarget / equivalent_injection.nominalVoltage
-        if 'inService' in equivalent_injection.columns:
-            equivalent_injection['connected'] = equivalent_injection['connected'] & equivalent_injection['inService']
+        if self.cimConverter.cim_version == '3.0':
+           equivalent_injection['in_service'] = equivalent_injection.connected & equivalent_injection.inService
+        elif self.cimConverter.cim_version == 'ltds':
+           equivalent_injection['in_service'] = equivalent_injection.inService
+        else:
+           equivalent_injection['in_service'] = equivalent_injection.connected
         equivalent_injection = equivalent_injection.rename(
-            columns={'rdfId_Terminal': sc['t'], 'rdfId': sc['o_id'], 'connected': 'in_service', 'index_bus': 'bus',
-                     'p': 'ps_mw', 'q': 'qs_mvar'})
+            columns={'rdfId_Terminal': sc['t'], 'rdfId': sc['o_id'], 'index_bus': 'bus', 'p': 'ps_mw', 'q': 'qs_mvar'})
         equivalent_injection['pz_mw'] = 0.
         equivalent_injection['qz_mvar'] = 0.
         equivalent_injection['r_ohm'] = 0.

--- a/pandapower/converter/cim/cim2pp/from_cim.py
+++ b/pandapower/converter/cim/cim2pp/from_cim.py
@@ -23,6 +23,7 @@ def from_cim_dict(cim_parser: cim_classes.CimParser, log_debug=False, convert_li
                   repair_pp: Union[str, interfaces.PandapowerRepair] = None,
                   repair_pp_class: Type[interfaces.PandapowerRepair] = None,
                   custom_converter_classes: Dict = None,
+                  cim_version: str = None,
                   **kwargs) -> pandapowerNet:
     """
     Creates a pandapower net from a CIM data structure.
@@ -39,8 +40,11 @@ def from_cim_dict(cim_parser: cim_classes.CimParser, log_debug=False, convert_li
     :param repair_pp: The PandapowerRepair object or a path to its serialized object. Optional, default: None
     :param repair_pp_class: The PandapowerRepair class. Optional, default: None
     :param custom_converter_classes: Dict to inject classes for different functionality. Optional, default: None
+    :param cim_version: The CIM / CGMES / LTDS version. Optional, default: None
     :return: The pandapower net.
     """
+    if cim_version is None:
+        cim_version = '2.4.15'
     converter_classes = get_converter_classes()
     if custom_converter_classes is not None:
         for key in custom_converter_classes:
@@ -51,7 +55,8 @@ def from_cim_dict(cim_parser: cim_classes.CimParser, log_debug=False, convert_li
         repair_cim = repair_cim_class().deserialize(repair_cim, report_container=cim_parser.get_report_container())
         repair_cim.repair(cim_parser.get_cim_dict(), report_container=cim_parser.get_report_container())
 
-    cim_converter = build_pp_net.CimConverter(cim_parser=cim_parser, converter_classes=converter_classes, **kwargs)
+    cim_converter = build_pp_net.CimConverter(cim_parser=cim_parser, converter_classes=converter_classes,
+                                              cim_version=cim_version, **kwargs)
     pp_net = cim_converter.convert_to_pp(convert_line_to_switch=convert_line_to_switch, line_r_limit=line_r_limit,
                                          line_x_limit=line_x_limit, log_debug=log_debug, **kwargs)
 
@@ -121,20 +126,21 @@ def from_cim(file_list: Union[str, List[str]] = None, encoding: str = None, conv
     Default: False.
     - ignore_errors (bool): Option to disable raising of internal errors. Useful if you need to get a network not matter
     if there are errors in the conversion. Default: True.
+    - set_switch_impedance (bool): Set the line impedance for lines that will be converted to switches
 
     :param file_list: The path to the CGMES files as a string or list.
     :param encoding: The encoding from the files. Optional, default: None
     :param convert_line_to_switch: Set this parameter to True to enable line -> switch conversion. All lines with a
         resistance lower or equal than line_r_limit or a reactance lower or equal than line_x_limit will become a
         switch. Optional, default: False
-    :param line_r_limit: The limit from resistance. Optional, default: 0.1
-    :param line_x_limit: The limit from reactance. Optional, default: 0.1
+    :param line_r_limit: The limit from resistance for converting line to switch. Optional, default: 0.1
+    :param line_x_limit: The limit from reactance for converting line to switch. Optional, default: 0.1
     :param repair_cim: The CIMRepair object or a path to its serialized object. Optional, default: None
     :param repair_cim_class: The CIMRepair class. Optional, default: None
     :param repair_pp: The PandapowerRepair object or a path to its serialized object. Optional, default: None
     :param repair_pp_class: The PandapowerRepair class. Optional, default: None
     :param custom_converter_classes: Dict to inject classes for different functionality. Optional, default: None
-    :param cgmes_version: The CGMES version of the files, can be 3.0 or 2.4.15. Optional, default: 2.4.15
+    :param cgmes_version: The CGMES version of the files, can be 3.0, 2.4.15 or LTDS. Optional, default: 2.4.15
     :return: The pandapower net.
     """
     time_start_parsing = time.time()
@@ -146,7 +152,7 @@ def from_cim(file_list: Union[str, List[str]] = None, encoding: str = None, conv
     pp_net = from_cim_dict(cim_parser, convert_line_to_switch=convert_line_to_switch,
                            line_r_limit=line_r_limit, line_x_limit=line_x_limit, repair_cim=repair_cim,
                            repair_cim_class=repair_cim_class, repair_pp=repair_pp, repair_pp_class=repair_pp_class,
-                           custom_converter_classes=custom_converter_classes, **kwargs)
+                           custom_converter_classes=custom_converter_classes, cim_version=cgmes_version, **kwargs)
     time_end_converting = time.time()
     logger.info("The pandapower net: \n%s" % pp_net)
 

--- a/pandapower/converter/cim/cim_classes.py
+++ b/pandapower/converter/cim/cim_classes.py
@@ -29,8 +29,8 @@ class CimParser:
         """
         self.logger = logging.getLogger(self.__class__.__name__)
         self.cgmes_version = '2.4.15' if cgmes_version is None else cgmes_version
-        self.__cim_blueprint: MappingProxyType[str, MappingProxyType[str, pd.DataFrame]] =\
-            self._initialize_cim_data_structure(self.cgmes_version)
+        self.__cim_blueprint: MappingProxyType[str, MappingProxyType[str, pd.DataFrame]] =(
+            self._initialize_cim_data_structure(self.cgmes_version))
         self.cim: dict[str, dict[str, pd.DataFrame]] = cim if cim is not None else self.get_cim_data_structure()
         self.file_names: dict[str, str] = {}
         self.report_container = ReportContainer()
@@ -439,8 +439,9 @@ class CimParser:
         if not isinstance(profile_list, list):
             profile_list = [profile_list]
         for one_profile in profile_list:
-            if '/EquipmentCore/' in one_profile or '/EquipmentOperation/' in one_profile or \
-                    '/EquipmentShortCircuit/' in one_profile or '/CoreEquipment-EU/' in one_profile:
+            if ('/EquipmentCore/' in one_profile or '/EquipmentOperation/' in one_profile or
+                    '/EquipmentShortCircuit/' in one_profile or '/CoreEquipment-EU/' in one_profile or
+                    '/LTDS/Equipment/' in one_profile):
                 return 'eq'
             elif '/SteadyStateHypothesis/' in one_profile or '/SteadyStateHypothesis-EU/' in one_profile:
                 return 'ssh'
@@ -474,7 +475,7 @@ class CimParser:
                                                  message="The CGMES profile could not be parsed from the XML."))
             raise Exception("The CGMES profile could not be parsed from the XML.")
 
-    def _parse_source_file(self, file: str, output: dict, encoding: str | None, profile_name: str | None = None):
+    def _parse_source_file(self, file: str, output: dict, encoding: str | None):
         self.logger.info(f"Parsing file: {file}")
         if not self._check_file(file):
             return
@@ -499,10 +500,7 @@ class CimParser:
             return
         parser = etree.XMLParser(encoding=encoding, resolve_entities=False, remove_comments=True)
         xml_tree = etree.parse(file, parser)
-        if profile_name is None:
-            prf = self._get_cgmes_profile_from_xml(xml_tree.getroot())
-        else:
-            prf = profile_name
+        prf = self._get_cgmes_profile_from_xml(xml_tree.getroot())
         self.file_names[prf] = file
         self._parse_xml_tree(xml_tree.getroot(), prf, output)
 
@@ -587,7 +585,7 @@ class CimParser:
     ) -> MappingProxyType[str, MappingProxyType[str, pd.DataFrame]]:
         if cgmes_version == '2.4.15':
             return self._initialize_cim16_data_structure()
-        if cgmes_version == '3.0':
+        if cgmes_version == '3.0' or cgmes_version.lower() == 'ltds':
             return self._initialize_cim100_data_structure()
         raise NotImplementedError(f"CGMES version {cgmes_version} is not supported.")
 
@@ -614,7 +612,8 @@ class CimParser:
                     'rdfId', 'name', 'description', 'minP', 'maxP', 'minQ', 'maxQ', 'BaseVoltage', 'EquipmentContainer',
                     'RegulatingControl', 'governorSCD']),
                 'ACLineSegment': pd.DataFrame(columns=[
-                    'rdfId', 'name', 'description', 'length', 'r', 'x', 'bch', 'gch', 'BaseVoltage', 'EquipmentContainer']),
+                    'rdfId', 'name', 'description', 'length', 'r', 'x', 'bch', 'gch', 'BaseVoltage',
+                    'EquipmentContainer']),
                 'Terminal': pd.DataFrame(columns=[
                     'rdfId', 'name', 'ConnectivityNode', 'ConductingEquipment', 'sequenceNumber']),
                 'OperationalLimitSet': pd.DataFrame(columns=['rdfId', 'name', 'Terminal']),
@@ -649,11 +648,16 @@ class CimParser:
                 'StationSupply': pd.DataFrame(columns=['rdfId', 'name', 'description', 'BaseVoltage']),
                 'GeneratingUnit': pd.DataFrame(columns=[
                     'rdfId', 'name', 'nominalP', 'minOperatingP', 'maxOperatingP', 'EquipmentContainer', 'governorSCD']),
-                'WindGeneratingUnit': pd.DataFrame(columns=['rdfId', 'nominalP', 'minOperatingP', 'maxOperatingP', 'governorSCD']),
-                'HydroGeneratingUnit': pd.DataFrame(columns=['rdfId', 'nominalP', 'minOperatingP', 'maxOperatingP', 'governorSCD']),
-                'SolarGeneratingUnit': pd.DataFrame(columns=['rdfId', 'nominalP', 'minOperatingP', 'maxOperatingP', 'governorSCD']),
-                'ThermalGeneratingUnit': pd.DataFrame(columns=['rdfId', 'nominalP', 'minOperatingP', 'maxOperatingP', 'governorSCD']),
-                'NuclearGeneratingUnit': pd.DataFrame(columns=['rdfId', 'nominalP', 'minOperatingP', 'maxOperatingP', 'governorSCD']),
+                'WindGeneratingUnit': pd.DataFrame(columns=[
+                    'rdfId', 'nominalP', 'minOperatingP', 'maxOperatingP', 'governorSCD']),
+                'HydroGeneratingUnit': pd.DataFrame(columns=[
+                    'rdfId', 'nominalP', 'minOperatingP', 'maxOperatingP', 'governorSCD']),
+                'SolarGeneratingUnit': pd.DataFrame(columns=[
+                    'rdfId', 'nominalP', 'minOperatingP', 'maxOperatingP', 'governorSCD']),
+                'ThermalGeneratingUnit': pd.DataFrame(columns=[
+                    'rdfId', 'nominalP', 'minOperatingP', 'maxOperatingP', 'governorSCD']),
+                'NuclearGeneratingUnit': pd.DataFrame(columns=[
+                    'rdfId', 'nominalP', 'minOperatingP', 'maxOperatingP', 'governorSCD']),
                 'RegulatingControl': pd.DataFrame(columns=['rdfId', 'name', 'mode', 'Terminal']),
                 'SynchronousMachine': pd.DataFrame(columns=[
                     'rdfId', 'name', 'description', 'GeneratingUnit', 'EquipmentContainer', 'ratedU', 'ratedS', 'type',
@@ -665,7 +669,8 @@ class CimParser:
                     'EquipmentContainer']),
                 'EnergySchedulingType': pd.DataFrame(columns=['rdfId', 'name']),
                 'StaticVarCompensator': pd.DataFrame(columns=['rdfId', 'name', 'description', 'voltageSetPoint','sVCControlMode']),
-                'PowerTransformer': pd.DataFrame(columns=['rdfId', 'name', 'description', 'EquipmentContainer']),
+                'PowerTransformer': pd.DataFrame(columns=[
+                    'rdfId', 'name', 'description', 'EquipmentContainer', 'inService']),
                 'PowerTransformerEnd': pd.DataFrame(columns=[
                     'rdfId', 'name', 'PowerTransformer', 'endNumber', 'Terminal', 'ratedS', 'ratedU',
                     'r', 'x', 'b', 'g', 'BaseVoltage', 'connectionKind']),
@@ -700,7 +705,8 @@ class CimParser:
                     'rdfId', 'description', 'NonlinearShuntCompensator', 'sectionNumber', 'b', 'g']),
                 'EquivalentBranch': pd.DataFrame(columns=[
                     'rdfId', 'name', 'description', 'BaseVoltage', 'r', 'x', 'r21', 'x21']),
-                'EquivalentInjection': pd.DataFrame(columns=['rdfId', 'name', 'description', 'BaseVoltage']),
+                'EquivalentInjection': pd.DataFrame(columns=['rdfId', 'name', 'description', 'BaseVoltage',
+                                                             'EquipmentContainer']),
                 'SeriesCompensator': pd.DataFrame(columns=[
                     'rdfId', 'name', 'description', 'BaseVoltage', 'r', 'x']),
                 'MeasurementValueSource': pd.DataFrame(columns=['rdfId', 'name']),
@@ -746,6 +752,7 @@ class CimParser:
                 'SeriesCompensator': pd.DataFrame(columns=['rdfId', 'r0', 'x0']),
             }),
             'ssh': MappingProxyType({
+                'Equipment': pd.DataFrame(columns=['rdfId', 'inService']),
                 'ControlArea': pd.DataFrame(columns=['rdfId', 'netInterchange']),
                 'ExternalNetworkInjection': pd.DataFrame(columns=[
                     'rdfId', 'p', 'q', 'referencePriority', 'controlEnabled', 'inService']),

--- a/pandapower/converter/cim/cim_tools.py
+++ b/pandapower/converter/cim/cim_tools.py
@@ -160,7 +160,7 @@ def get_cim_schema(cgmes_version: str = '2.4.15') -> Dict[str, Dict[str, Dict[st
     Parses the CIM schema from the serialized CIM schema json files which have been created from the RDF schema files.
     The schema is parsed for the serializer from the CIM data structure used by the cim2pp and pp2cim converters.
 
-    :param cgmes_version: CIM version to use, '2.4.15' or '3.0', default '2.4.15'
+    :param cgmes_version: CIM version to use, '2.4.15', '3.0' or LTDS, default '2.4.15'
     :return: The CIM schema as dictionary.
     """
     path_with_serialized_schemas = os.path.dirname(__file__) + os.sep + 'serialized_schemas'
@@ -173,7 +173,7 @@ def get_cim_schema(cgmes_version: str = '2.4.15') -> Dict[str, Dict[str, Dict[st
             with open(path_to_schema, encoding='UTF-8', mode='r') as f:
                 cim_schema = json.load(f)
             return cim_schema
-        elif one_file.lower().startswith('cim100_') and cgmes_version == '3.0':
+        elif one_file.lower().startswith('cim100_') and (cgmes_version == '3.0' or cgmes_version.lower() == 'ltds'):
             logger.info("Parsing the schema from CIM 100 from disk: %s" % path_to_schema)
             with open(path_to_schema, encoding='UTF-8', mode='r') as f:
                 cim_schema = json.load(f)

--- a/pandapower/converter/cim/serialized_schemas/CIM100_4.2.13_schema.json
+++ b/pandapower/converter/cim/serialized_schemas/CIM100_4.2.13_schema.json
@@ -1,0 +1,12702 @@
+{
+    "eq": {
+        "ControlArea": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ControlArea",
+            "fields": {
+                "type": {
+                    "label": "cim:ControlArea.type",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlAreaTypeKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlAreaTypeKind."
+                },
+                "TieFlow": {
+                    "label": "cim:ControlArea.TieFlow",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#TieFlow.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#TieFlow."
+                },
+                "ControlAreaGeneratingUnit": {
+                    "label": "cim:ControlArea.ControlAreaGeneratingUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlAreaGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlAreaGeneratingUnit."
+                },
+                "EnergyArea": {
+                    "label": "cim:ControlArea.EnergyArea",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "TieFlow": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:TieFlow",
+            "fields": {
+                "ControlArea": {
+                    "label": "cim:TieFlow.ControlArea",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminal": {
+                    "label": "cim:TieFlow.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "positiveFlowIn": {
+                    "label": "cim:TieFlow.positiveFlowIn",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ConnectivityNode": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ConnectivityNode",
+            "fields": {
+                "BoundaryPoint": {
+                    "label": "cim:ConnectivityNode.BoundaryPoint",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100-European#BoundaryPoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100-European#BoundaryPoint."
+                },
+                "Terminals": {
+                    "label": "cim:ConnectivityNode.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "ConnectivityNodeContainer": {
+                    "label": "cim:ConnectivityNode.ConnectivityNodeContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Bay": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Bay",
+            "fields": {
+                "VoltageLevel": {
+                    "label": "cim:Bay.VoltageLevel",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Equipments": {
+                    "label": "cim:EquipmentContainer.Equipments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Equipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Equipment."
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:ConnectivityNodeContainer.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "BusbarSection": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:BusbarSection",
+            "fields": {
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Substation": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Substation",
+            "fields": {
+                "DCConverterUnit": {
+                    "label": "cim:Substation.DCConverterUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCConverterUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCConverterUnit."
+                },
+                "Region": {
+                    "label": "cim:Substation.Region",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "VoltageLevels": {
+                    "label": "cim:Substation.VoltageLevels",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#VoltageLevel.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#VoltageLevel."
+                },
+                "Equipments": {
+                    "label": "cim:EquipmentContainer.Equipments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Equipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Equipment."
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:ConnectivityNodeContainer.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "GeographicalRegion": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:GeographicalRegion",
+            "fields": {
+                "Regions": {
+                    "label": "cim:GeographicalRegion.Regions",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SubGeographicalRegion.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SubGeographicalRegion."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SubGeographicalRegion": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SubGeographicalRegion",
+            "fields": {
+                "DCLines": {
+                    "label": "cim:SubGeographicalRegion.DCLines",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCLine.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCLine."
+                },
+                "Region": {
+                    "label": "cim:SubGeographicalRegion.Region",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Lines": {
+                    "label": "cim:SubGeographicalRegion.Lines",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Line.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Line."
+                },
+                "Substations": {
+                    "label": "cim:SubGeographicalRegion.Substations",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Substation.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Substation."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "VoltageLevel": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:VoltageLevel",
+            "fields": {
+                "BaseVoltage": {
+                    "label": "cim:VoltageLevel.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Bays": {
+                    "label": "cim:VoltageLevel.Bays",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Bay.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Bay."
+                },
+                "Substation": {
+                    "label": "cim:VoltageLevel.Substation",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "highVoltageLimit": {
+                    "label": "cim:VoltageLevel.highVoltageLimit",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "lowVoltageLimit": {
+                    "label": "cim:VoltageLevel.lowVoltageLimit",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "Equipments": {
+                    "label": "cim:EquipmentContainer.Equipments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Equipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Equipment."
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:ConnectivityNodeContainer.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "BaseVoltage": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:BaseVoltage",
+            "fields": {
+                "nominalVoltage": {
+                    "label": "cim:BaseVoltage.nominalVoltage",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "ConductingEquipment": {
+                    "label": "cim:BaseVoltage.ConductingEquipment",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConductingEquipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConductingEquipment."
+                },
+                "VoltageLevel": {
+                    "label": "cim:BaseVoltage.VoltageLevel",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#VoltageLevel.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#VoltageLevel."
+                },
+                "TransformerEnds": {
+                    "label": "cim:BaseVoltage.TransformerEnds",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#TransformerEnd.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#TransformerEnd."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ExternalNetworkInjection": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ExternalNetworkInjection",
+            "fields": {
+                "governorSCD": {
+                    "label": "cim:ExternalNetworkInjection.governorSCD",
+                    "data_type": "ActivePowerPerFrequency",
+                    "data_type_prim": "Float"
+                },
+                "maxP": {
+                    "label": "cim:ExternalNetworkInjection.maxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "maxQ": {
+                    "label": "cim:ExternalNetworkInjection.maxQ",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "minP": {
+                    "label": "cim:ExternalNetworkInjection.minP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minQ": {
+                    "label": "cim:ExternalNetworkInjection.minQ",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "RegulatingControl": {
+                    "label": "cim:RegulatingCondEq.RegulatingControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ACLineSegment": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ACLineSegment",
+            "fields": {
+                "bch": {
+                    "label": "cim:ACLineSegment.bch",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "gch": {
+                    "label": "cim:ACLineSegment.gch",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                },
+                "r": {
+                    "label": "cim:ACLineSegment.r",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "x": {
+                    "label": "cim:ACLineSegment.x",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "Clamp": {
+                    "label": "cim:ACLineSegment.Clamp",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Clamp.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Clamp."
+                },
+                "Cut": {
+                    "label": "cim:ACLineSegment.Cut",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Cut.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Cut."
+                },
+                "length": {
+                    "label": "cim:Conductor.length",
+                    "data_type": "Length",
+                    "data_type_prim": "Float"
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Terminal": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Terminal",
+            "fields": {
+                "ConverterDCSides": {
+                    "label": "cim:Terminal.ConverterDCSides",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ACDCConverter.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ACDCConverter."
+                },
+                "AuxiliaryEquipment": {
+                    "label": "cim:Terminal.AuxiliaryEquipment",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#AuxiliaryEquipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#AuxiliaryEquipment."
+                },
+                "ConductingEquipment": {
+                    "label": "cim:Terminal.ConductingEquipment",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ConnectivityNode": {
+                    "label": "cim:Terminal.ConnectivityNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "RegulatingControl": {
+                    "label": "cim:Terminal.RegulatingControl",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegulatingControl.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegulatingControl."
+                },
+                "phases": {
+                    "label": "cim:Terminal.phases",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#PhaseCode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#PhaseCode."
+                },
+                "TransformerEnd": {
+                    "label": "cim:Terminal.TransformerEnd",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#TransformerEnd.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#TransformerEnd."
+                },
+                "TieFlow": {
+                    "label": "cim:Terminal.TieFlow",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#TieFlow.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#TieFlow."
+                },
+                "sequenceNumber": {
+                    "label": "cim:ACDCTerminal.sequenceNumber",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:ACDCTerminal.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "BusNameMarker": {
+                    "label": "cim:ACDCTerminal.BusNameMarker",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "OperationalLimitSet": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:OperationalLimitSet",
+            "fields": {
+                "Terminal": {
+                    "label": "cim:OperationalLimitSet.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Equipment": {
+                    "label": "cim:OperationalLimitSet.Equipment",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitValue": {
+                    "label": "cim:OperationalLimitSet.OperationalLimitValue",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimit."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "OperationalLimitType": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:OperationalLimitType",
+            "fields": {
+                "OperationalLimit": {
+                    "label": "cim:OperationalLimitType.OperationalLimit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimit."
+                },
+                "acceptableDuration": {
+                    "label": "cim:OperationalLimitType.acceptableDuration",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "direction": {
+                    "label": "cim:OperationalLimitType.direction",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitDirectionKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitDirectionKind."
+                },
+                "isInfiniteDuration": {
+                    "label": "cim:OperationalLimitType.isInfiniteDuration",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "kind": {
+                    "label": "cim:OperationalLimitType.kind",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100-European#LimitKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100-European#LimitKind."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "CurrentLimit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:CurrentLimit",
+            "fields": {
+                "normalValue": {
+                    "label": "cim:CurrentLimit.normalValue",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:OperationalLimit.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitType": {
+                    "label": "cim:OperationalLimit.OperationalLimitType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "VoltageLimit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:VoltageLimit",
+            "fields": {
+                "normalValue": {
+                    "label": "cim:VoltageLimit.normalValue",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:OperationalLimit.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitType": {
+                    "label": "cim:OperationalLimit.OperationalLimitType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCNode": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCNode",
+            "fields": {
+                "DCTerminals": {
+                    "label": "cim:DCNode.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCBaseTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCBaseTerminal."
+                },
+                "DCEquipmentContainer": {
+                    "label": "cim:DCNode.DCEquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCEquipmentContainer": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCEquipmentContainer",
+            "fields": {
+                "DCNodes": {
+                    "label": "cim:DCEquipmentContainer.DCNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCNode."
+                },
+                "Equipments": {
+                    "label": "cim:EquipmentContainer.Equipments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Equipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Equipment."
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:ConnectivityNodeContainer.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCLine": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCLine",
+            "fields": {
+                "Region": {
+                    "label": "cim:DCLine.Region",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DCNodes": {
+                    "label": "cim:DCEquipmentContainer.DCNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCNode."
+                },
+                "Equipments": {
+                    "label": "cim:EquipmentContainer.Equipments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Equipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Equipment."
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:ConnectivityNodeContainer.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCConverterUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCConverterUnit",
+            "fields": {
+                "operationMode": {
+                    "label": "cim:DCConverterUnit.operationMode",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCConverterOperatingModeKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCConverterOperatingModeKind."
+                },
+                "Substation": {
+                    "label": "cim:DCConverterUnit.Substation",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DCNodes": {
+                    "label": "cim:DCEquipmentContainer.DCNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCNode."
+                },
+                "Equipments": {
+                    "label": "cim:EquipmentContainer.Equipments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Equipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Equipment."
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:ConnectivityNodeContainer.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCLineSegment": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCLineSegment",
+            "fields": {
+                "capacitance": {
+                    "label": "cim:DCLineSegment.capacitance",
+                    "data_type": "Capacitance",
+                    "data_type_prim": "Float"
+                },
+                "inductance": {
+                    "label": "cim:DCLineSegment.inductance",
+                    "data_type": "Inductance",
+                    "data_type_prim": "Float"
+                },
+                "resistance": {
+                    "label": "cim:DCLineSegment.resistance",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "length": {
+                    "label": "cim:DCLineSegment.length",
+                    "data_type": "Length",
+                    "data_type_prim": "Float"
+                },
+                "ratedUdc": {
+                    "label": "cim:DCConductingEquipment.ratedUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "DCTerminals": {
+                    "label": "cim:DCConductingEquipment.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCTerminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "CsConverter": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:CsConverter",
+            "fields": {
+                "maxAlpha": {
+                    "label": "cim:CsConverter.maxAlpha",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "maxGamma": {
+                    "label": "cim:CsConverter.maxGamma",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "maxIdc": {
+                    "label": "cim:CsConverter.maxIdc",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "minAlpha": {
+                    "label": "cim:CsConverter.minAlpha",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "minGamma": {
+                    "label": "cim:CsConverter.minGamma",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "minIdc": {
+                    "label": "cim:CsConverter.minIdc",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "ratedIdc": {
+                    "label": "cim:CsConverter.ratedIdc",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "baseS": {
+                    "label": "cim:ACDCConverter.baseS",
+                    "data_type": "ApparentPower",
+                    "data_type_prim": "Float"
+                },
+                "idleLoss": {
+                    "label": "cim:ACDCConverter.idleLoss",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "maxUdc": {
+                    "label": "cim:ACDCConverter.maxUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "minUdc": {
+                    "label": "cim:ACDCConverter.minUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "numberOfValves": {
+                    "label": "cim:ACDCConverter.numberOfValves",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "ratedUdc": {
+                    "label": "cim:ACDCConverter.ratedUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "resistiveLoss": {
+                    "label": "cim:ACDCConverter.resistiveLoss",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "switchingLoss": {
+                    "label": "cim:ACDCConverter.switchingLoss",
+                    "data_type": "ActivePowerPerCurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "valveU0": {
+                    "label": "cim:ACDCConverter.valveU0",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "maxP": {
+                    "label": "cim:ACDCConverter.maxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minP": {
+                    "label": "cim:ACDCConverter.minP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "PccTerminal": {
+                    "label": "cim:ACDCConverter.PccTerminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DCTerminals": {
+                    "label": "cim:ACDCConverter.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ACDCConverterDCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ACDCConverterDCTerminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "VsConverter": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:VsConverter",
+            "fields": {
+                "CapabilityCurve": {
+                    "label": "cim:VsConverter.CapabilityCurve",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "maxModulationIndex": {
+                    "label": "cim:VsConverter.maxModulationIndex",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "baseS": {
+                    "label": "cim:ACDCConverter.baseS",
+                    "data_type": "ApparentPower",
+                    "data_type_prim": "Float"
+                },
+                "idleLoss": {
+                    "label": "cim:ACDCConverter.idleLoss",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "maxUdc": {
+                    "label": "cim:ACDCConverter.maxUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "minUdc": {
+                    "label": "cim:ACDCConverter.minUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "numberOfValves": {
+                    "label": "cim:ACDCConverter.numberOfValves",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "ratedUdc": {
+                    "label": "cim:ACDCConverter.ratedUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "resistiveLoss": {
+                    "label": "cim:ACDCConverter.resistiveLoss",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "switchingLoss": {
+                    "label": "cim:ACDCConverter.switchingLoss",
+                    "data_type": "ActivePowerPerCurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "valveU0": {
+                    "label": "cim:ACDCConverter.valveU0",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "maxP": {
+                    "label": "cim:ACDCConverter.maxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minP": {
+                    "label": "cim:ACDCConverter.minP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "PccTerminal": {
+                    "label": "cim:ACDCConverter.PccTerminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DCTerminals": {
+                    "label": "cim:ACDCConverter.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ACDCConverterDCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ACDCConverterDCTerminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCTerminal": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCTerminal",
+            "fields": {
+                "DCConductingEquipment": {
+                    "label": "cim:DCTerminal.DCConductingEquipment",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DCNode": {
+                    "label": "cim:DCBaseTerminal.DCNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "sequenceNumber": {
+                    "label": "cim:ACDCTerminal.sequenceNumber",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:ACDCTerminal.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "BusNameMarker": {
+                    "label": "cim:ACDCTerminal.BusNameMarker",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ACDCConverterDCTerminal": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ACDCConverterDCTerminal",
+            "fields": {
+                "DCConductingEquipment": {
+                    "label": "cim:ACDCConverterDCTerminal.DCConductingEquipment",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "polarity": {
+                    "label": "cim:ACDCConverterDCTerminal.polarity",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCPolarityKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCPolarityKind."
+                },
+                "DCNode": {
+                    "label": "cim:DCBaseTerminal.DCNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "sequenceNumber": {
+                    "label": "cim:ACDCTerminal.sequenceNumber",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:ACDCTerminal.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "BusNameMarker": {
+                    "label": "cim:ACDCTerminal.BusNameMarker",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Breaker": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Breaker",
+            "fields": {
+                "normalOpen": {
+                    "label": "cim:Switch.normalOpen",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "ratedCurrent": {
+                    "label": "cim:Switch.ratedCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "retained": {
+                    "label": "cim:Switch.retained",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "SwitchSchedules": {
+                    "label": "cim:Switch.SwitchSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SwitchSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SwitchSchedule."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Disconnector": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Disconnector",
+            "fields": {
+                "normalOpen": {
+                    "label": "cim:Switch.normalOpen",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "ratedCurrent": {
+                    "label": "cim:Switch.ratedCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "retained": {
+                    "label": "cim:Switch.retained",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "SwitchSchedules": {
+                    "label": "cim:Switch.SwitchSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SwitchSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SwitchSchedule."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Switch": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Switch",
+            "fields": {
+                "normalOpen": {
+                    "label": "cim:Switch.normalOpen",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "ratedCurrent": {
+                    "label": "cim:Switch.ratedCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "retained": {
+                    "label": "cim:Switch.retained",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "SwitchSchedules": {
+                    "label": "cim:Switch.SwitchSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SwitchSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SwitchSchedule."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "LoadBreakSwitch": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:LoadBreakSwitch",
+            "fields": {
+                "normalOpen": {
+                    "label": "cim:Switch.normalOpen",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "ratedCurrent": {
+                    "label": "cim:Switch.ratedCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "retained": {
+                    "label": "cim:Switch.retained",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "SwitchSchedules": {
+                    "label": "cim:Switch.SwitchSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SwitchSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SwitchSchedule."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EnergyConsumer": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:EnergyConsumer",
+            "fields": {
+                "pfixed": {
+                    "label": "cim:EnergyConsumer.pfixed",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "pfixedPct": {
+                    "label": "cim:EnergyConsumer.pfixedPct",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "qfixed": {
+                    "label": "cim:EnergyConsumer.qfixed",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "qfixedPct": {
+                    "label": "cim:EnergyConsumer.qfixedPct",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "LoadResponse": {
+                    "label": "cim:EnergyConsumer.LoadResponse",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ConformLoad": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ConformLoad",
+            "fields": {
+                "LoadGroup": {
+                    "label": "cim:ConformLoad.LoadGroup",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "pfixed": {
+                    "label": "cim:EnergyConsumer.pfixed",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "pfixedPct": {
+                    "label": "cim:EnergyConsumer.pfixedPct",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "qfixed": {
+                    "label": "cim:EnergyConsumer.qfixed",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "qfixedPct": {
+                    "label": "cim:EnergyConsumer.qfixedPct",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "LoadResponse": {
+                    "label": "cim:EnergyConsumer.LoadResponse",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "NonConformLoad": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:NonConformLoad",
+            "fields": {
+                "LoadGroup": {
+                    "label": "cim:NonConformLoad.LoadGroup",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "pfixed": {
+                    "label": "cim:EnergyConsumer.pfixed",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "pfixedPct": {
+                    "label": "cim:EnergyConsumer.pfixedPct",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "qfixed": {
+                    "label": "cim:EnergyConsumer.qfixed",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "qfixedPct": {
+                    "label": "cim:EnergyConsumer.qfixedPct",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "LoadResponse": {
+                    "label": "cim:EnergyConsumer.LoadResponse",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "StationSupply": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:StationSupply",
+            "fields": {
+                "pfixed": {
+                    "label": "cim:EnergyConsumer.pfixed",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "pfixedPct": {
+                    "label": "cim:EnergyConsumer.pfixedPct",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "qfixed": {
+                    "label": "cim:EnergyConsumer.qfixed",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "qfixedPct": {
+                    "label": "cim:EnergyConsumer.qfixedPct",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "LoadResponse": {
+                    "label": "cim:EnergyConsumer.LoadResponse",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "GeneratingUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:GeneratingUnit",
+            "fields": {
+                "ControlAreaGeneratingUnit": {
+                    "label": "cim:GeneratingUnit.ControlAreaGeneratingUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlAreaGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlAreaGeneratingUnit."
+                },
+                "genControlSource": {
+                    "label": "cim:GeneratingUnit.genControlSource",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#GeneratorControlSource.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#GeneratorControlSource."
+                },
+                "governorSCD": {
+                    "label": "cim:GeneratingUnit.governorSCD",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "longPF": {
+                    "label": "cim:GeneratingUnit.longPF",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "maximumAllowableSpinningReserve": {
+                    "label": "cim:GeneratingUnit.maximumAllowableSpinningReserve",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "maxOperatingP": {
+                    "label": "cim:GeneratingUnit.maxOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minOperatingP": {
+                    "label": "cim:GeneratingUnit.minOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "nominalP": {
+                    "label": "cim:GeneratingUnit.nominalP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMaxP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMinP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMinP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedNetMaxP": {
+                    "label": "cim:GeneratingUnit.ratedNetMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "shortPF": {
+                    "label": "cim:GeneratingUnit.shortPF",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "startupCost": {
+                    "label": "cim:GeneratingUnit.startupCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "variableCost": {
+                    "label": "cim:GeneratingUnit.variableCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "startupTime": {
+                    "label": "cim:GeneratingUnit.startupTime",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "totalEfficiency": {
+                    "label": "cim:GeneratingUnit.totalEfficiency",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "GrossToNetActivePowerCurves": {
+                    "label": "cim:GeneratingUnit.GrossToNetActivePowerCurves",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#GrossToNetActivePowerCurve.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#GrossToNetActivePowerCurve."
+                },
+                "RotatingMachine": {
+                    "label": "cim:GeneratingUnit.RotatingMachine",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RotatingMachine.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RotatingMachine."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "WindGeneratingUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:WindGeneratingUnit",
+            "fields": {
+                "windGenUnitType": {
+                    "label": "cim:WindGeneratingUnit.windGenUnitType",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#WindGenUnitKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#WindGenUnitKind."
+                },
+                "WindPowerPlant": {
+                    "label": "cim:WindGeneratingUnit.WindPowerPlant",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ControlAreaGeneratingUnit": {
+                    "label": "cim:GeneratingUnit.ControlAreaGeneratingUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlAreaGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlAreaGeneratingUnit."
+                },
+                "genControlSource": {
+                    "label": "cim:GeneratingUnit.genControlSource",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#GeneratorControlSource.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#GeneratorControlSource."
+                },
+                "governorSCD": {
+                    "label": "cim:GeneratingUnit.governorSCD",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "longPF": {
+                    "label": "cim:GeneratingUnit.longPF",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "maximumAllowableSpinningReserve": {
+                    "label": "cim:GeneratingUnit.maximumAllowableSpinningReserve",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "maxOperatingP": {
+                    "label": "cim:GeneratingUnit.maxOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minOperatingP": {
+                    "label": "cim:GeneratingUnit.minOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "nominalP": {
+                    "label": "cim:GeneratingUnit.nominalP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMaxP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMinP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMinP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedNetMaxP": {
+                    "label": "cim:GeneratingUnit.ratedNetMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "shortPF": {
+                    "label": "cim:GeneratingUnit.shortPF",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "startupCost": {
+                    "label": "cim:GeneratingUnit.startupCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "variableCost": {
+                    "label": "cim:GeneratingUnit.variableCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "startupTime": {
+                    "label": "cim:GeneratingUnit.startupTime",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "totalEfficiency": {
+                    "label": "cim:GeneratingUnit.totalEfficiency",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "GrossToNetActivePowerCurves": {
+                    "label": "cim:GeneratingUnit.GrossToNetActivePowerCurves",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#GrossToNetActivePowerCurve.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#GrossToNetActivePowerCurve."
+                },
+                "RotatingMachine": {
+                    "label": "cim:GeneratingUnit.RotatingMachine",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RotatingMachine.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RotatingMachine."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "HydroGeneratingUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:HydroGeneratingUnit",
+            "fields": {
+                "energyConversionCapability": {
+                    "label": "cim:HydroGeneratingUnit.energyConversionCapability",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#HydroEnergyConversionKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#HydroEnergyConversionKind."
+                },
+                "dropHeight": {
+                    "label": "cim:HydroGeneratingUnit.dropHeight",
+                    "data_type": "Length",
+                    "data_type_prim": "Float"
+                },
+                "turbineType": {
+                    "label": "cim:HydroGeneratingUnit.turbineType",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#HydroTurbineKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#HydroTurbineKind."
+                },
+                "HydroPowerPlant": {
+                    "label": "cim:HydroGeneratingUnit.HydroPowerPlant",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ControlAreaGeneratingUnit": {
+                    "label": "cim:GeneratingUnit.ControlAreaGeneratingUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlAreaGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlAreaGeneratingUnit."
+                },
+                "genControlSource": {
+                    "label": "cim:GeneratingUnit.genControlSource",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#GeneratorControlSource.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#GeneratorControlSource."
+                },
+                "governorSCD": {
+                    "label": "cim:GeneratingUnit.governorSCD",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "longPF": {
+                    "label": "cim:GeneratingUnit.longPF",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "maximumAllowableSpinningReserve": {
+                    "label": "cim:GeneratingUnit.maximumAllowableSpinningReserve",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "maxOperatingP": {
+                    "label": "cim:GeneratingUnit.maxOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minOperatingP": {
+                    "label": "cim:GeneratingUnit.minOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "nominalP": {
+                    "label": "cim:GeneratingUnit.nominalP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMaxP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMinP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMinP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedNetMaxP": {
+                    "label": "cim:GeneratingUnit.ratedNetMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "shortPF": {
+                    "label": "cim:GeneratingUnit.shortPF",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "startupCost": {
+                    "label": "cim:GeneratingUnit.startupCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "variableCost": {
+                    "label": "cim:GeneratingUnit.variableCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "startupTime": {
+                    "label": "cim:GeneratingUnit.startupTime",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "totalEfficiency": {
+                    "label": "cim:GeneratingUnit.totalEfficiency",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "GrossToNetActivePowerCurves": {
+                    "label": "cim:GeneratingUnit.GrossToNetActivePowerCurves",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#GrossToNetActivePowerCurve.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#GrossToNetActivePowerCurve."
+                },
+                "RotatingMachine": {
+                    "label": "cim:GeneratingUnit.RotatingMachine",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RotatingMachine.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RotatingMachine."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SolarGeneratingUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SolarGeneratingUnit",
+            "fields": {
+                "SolarPowerPlant": {
+                    "label": "cim:SolarGeneratingUnit.SolarPowerPlant",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ControlAreaGeneratingUnit": {
+                    "label": "cim:GeneratingUnit.ControlAreaGeneratingUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlAreaGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlAreaGeneratingUnit."
+                },
+                "genControlSource": {
+                    "label": "cim:GeneratingUnit.genControlSource",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#GeneratorControlSource.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#GeneratorControlSource."
+                },
+                "governorSCD": {
+                    "label": "cim:GeneratingUnit.governorSCD",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "longPF": {
+                    "label": "cim:GeneratingUnit.longPF",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "maximumAllowableSpinningReserve": {
+                    "label": "cim:GeneratingUnit.maximumAllowableSpinningReserve",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "maxOperatingP": {
+                    "label": "cim:GeneratingUnit.maxOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minOperatingP": {
+                    "label": "cim:GeneratingUnit.minOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "nominalP": {
+                    "label": "cim:GeneratingUnit.nominalP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMaxP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMinP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMinP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedNetMaxP": {
+                    "label": "cim:GeneratingUnit.ratedNetMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "shortPF": {
+                    "label": "cim:GeneratingUnit.shortPF",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "startupCost": {
+                    "label": "cim:GeneratingUnit.startupCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "variableCost": {
+                    "label": "cim:GeneratingUnit.variableCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "startupTime": {
+                    "label": "cim:GeneratingUnit.startupTime",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "totalEfficiency": {
+                    "label": "cim:GeneratingUnit.totalEfficiency",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "GrossToNetActivePowerCurves": {
+                    "label": "cim:GeneratingUnit.GrossToNetActivePowerCurves",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#GrossToNetActivePowerCurve.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#GrossToNetActivePowerCurve."
+                },
+                "RotatingMachine": {
+                    "label": "cim:GeneratingUnit.RotatingMachine",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RotatingMachine.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RotatingMachine."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ThermalGeneratingUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ThermalGeneratingUnit",
+            "fields": {
+                "CAESPlant": {
+                    "label": "cim:ThermalGeneratingUnit.CAESPlant",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "CogenerationPlant": {
+                    "label": "cim:ThermalGeneratingUnit.CogenerationPlant",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "CombinedCyclePlant": {
+                    "label": "cim:ThermalGeneratingUnit.CombinedCyclePlant",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "FossilFuels": {
+                    "label": "cim:ThermalGeneratingUnit.FossilFuels",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#FossilFuel.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#FossilFuel."
+                },
+                "ControlAreaGeneratingUnit": {
+                    "label": "cim:GeneratingUnit.ControlAreaGeneratingUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlAreaGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlAreaGeneratingUnit."
+                },
+                "genControlSource": {
+                    "label": "cim:GeneratingUnit.genControlSource",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#GeneratorControlSource.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#GeneratorControlSource."
+                },
+                "governorSCD": {
+                    "label": "cim:GeneratingUnit.governorSCD",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "longPF": {
+                    "label": "cim:GeneratingUnit.longPF",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "maximumAllowableSpinningReserve": {
+                    "label": "cim:GeneratingUnit.maximumAllowableSpinningReserve",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "maxOperatingP": {
+                    "label": "cim:GeneratingUnit.maxOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minOperatingP": {
+                    "label": "cim:GeneratingUnit.minOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "nominalP": {
+                    "label": "cim:GeneratingUnit.nominalP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMaxP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMinP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMinP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedNetMaxP": {
+                    "label": "cim:GeneratingUnit.ratedNetMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "shortPF": {
+                    "label": "cim:GeneratingUnit.shortPF",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "startupCost": {
+                    "label": "cim:GeneratingUnit.startupCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "variableCost": {
+                    "label": "cim:GeneratingUnit.variableCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "startupTime": {
+                    "label": "cim:GeneratingUnit.startupTime",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "totalEfficiency": {
+                    "label": "cim:GeneratingUnit.totalEfficiency",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "GrossToNetActivePowerCurves": {
+                    "label": "cim:GeneratingUnit.GrossToNetActivePowerCurves",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#GrossToNetActivePowerCurve.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#GrossToNetActivePowerCurve."
+                },
+                "RotatingMachine": {
+                    "label": "cim:GeneratingUnit.RotatingMachine",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RotatingMachine.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RotatingMachine."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "NuclearGeneratingUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:NuclearGeneratingUnit",
+            "fields": {
+                "ControlAreaGeneratingUnit": {
+                    "label": "cim:GeneratingUnit.ControlAreaGeneratingUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlAreaGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlAreaGeneratingUnit."
+                },
+                "genControlSource": {
+                    "label": "cim:GeneratingUnit.genControlSource",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#GeneratorControlSource.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#GeneratorControlSource."
+                },
+                "governorSCD": {
+                    "label": "cim:GeneratingUnit.governorSCD",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "longPF": {
+                    "label": "cim:GeneratingUnit.longPF",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "maximumAllowableSpinningReserve": {
+                    "label": "cim:GeneratingUnit.maximumAllowableSpinningReserve",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "maxOperatingP": {
+                    "label": "cim:GeneratingUnit.maxOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minOperatingP": {
+                    "label": "cim:GeneratingUnit.minOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "nominalP": {
+                    "label": "cim:GeneratingUnit.nominalP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMaxP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMinP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMinP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedNetMaxP": {
+                    "label": "cim:GeneratingUnit.ratedNetMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "shortPF": {
+                    "label": "cim:GeneratingUnit.shortPF",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "startupCost": {
+                    "label": "cim:GeneratingUnit.startupCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "variableCost": {
+                    "label": "cim:GeneratingUnit.variableCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "startupTime": {
+                    "label": "cim:GeneratingUnit.startupTime",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "totalEfficiency": {
+                    "label": "cim:GeneratingUnit.totalEfficiency",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "GrossToNetActivePowerCurves": {
+                    "label": "cim:GeneratingUnit.GrossToNetActivePowerCurves",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#GrossToNetActivePowerCurve.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#GrossToNetActivePowerCurve."
+                },
+                "RotatingMachine": {
+                    "label": "cim:GeneratingUnit.RotatingMachine",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RotatingMachine.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RotatingMachine."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "RegulatingControl": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:RegulatingControl",
+            "fields": {
+                "RegulationSchedule": {
+                    "label": "cim:RegulatingControl.RegulationSchedule",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegulationSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegulationSchedule."
+                },
+                "RegulatingCondEq": {
+                    "label": "cim:RegulatingControl.RegulatingCondEq",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegulatingCondEq.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegulatingCondEq."
+                },
+                "mode": {
+                    "label": "cim:RegulatingControl.mode",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegulatingControlModeKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegulatingControlModeKind."
+                },
+                "Terminal": {
+                    "label": "cim:RegulatingControl.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SynchronousMachine": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SynchronousMachine",
+            "fields": {
+                "InitialReactiveCapabilityCurve": {
+                    "label": "cim:SynchronousMachine.InitialReactiveCapabilityCurve",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "maxQ": {
+                    "label": "cim:SynchronousMachine.maxQ",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "minQ": {
+                    "label": "cim:SynchronousMachine.minQ",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "qPercent": {
+                    "label": "cim:SynchronousMachine.qPercent",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "type": {
+                    "label": "cim:SynchronousMachine.type",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SynchronousMachineKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SynchronousMachineKind."
+                },
+                "GeneratingUnit": {
+                    "label": "cim:RotatingMachine.GeneratingUnit",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "HydroPump": {
+                    "label": "cim:RotatingMachine.HydroPump",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#HydroPump.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#HydroPump."
+                },
+                "ratedPowerFactor": {
+                    "label": "cim:RotatingMachine.ratedPowerFactor",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "ratedS": {
+                    "label": "cim:RotatingMachine.ratedS",
+                    "data_type": "ApparentPower",
+                    "data_type_prim": "Float"
+                },
+                "ratedU": {
+                    "label": "cim:RotatingMachine.ratedU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "RegulatingControl": {
+                    "label": "cim:RegulatingCondEq.RegulatingControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "AsynchronousMachine": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:AsynchronousMachine",
+            "fields": {
+                "nominalFrequency": {
+                    "label": "cim:AsynchronousMachine.nominalFrequency",
+                    "data_type": "Frequency",
+                    "data_type_prim": "Float"
+                },
+                "nominalSpeed": {
+                    "label": "cim:AsynchronousMachine.nominalSpeed",
+                    "data_type": "RotationSpeed",
+                    "data_type_prim": "Float"
+                },
+                "GeneratingUnit": {
+                    "label": "cim:RotatingMachine.GeneratingUnit",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "HydroPump": {
+                    "label": "cim:RotatingMachine.HydroPump",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#HydroPump.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#HydroPump."
+                },
+                "ratedPowerFactor": {
+                    "label": "cim:RotatingMachine.ratedPowerFactor",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "ratedS": {
+                    "label": "cim:RotatingMachine.ratedS",
+                    "data_type": "ApparentPower",
+                    "data_type_prim": "Float"
+                },
+                "ratedU": {
+                    "label": "cim:RotatingMachine.ratedU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "RegulatingControl": {
+                    "label": "cim:RegulatingCondEq.RegulatingControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EnergySource": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:EnergySource",
+            "fields": {
+                "EnergySchedulingType": {
+                    "label": "cim:EnergySource.EnergySchedulingType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "nominalVoltage": {
+                    "label": "cim:EnergySource.nominalVoltage",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "pMin": {
+                    "label": "cim:EnergySource.pMin",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "pMax": {
+                    "label": "cim:EnergySource.pMax",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EnergySchedulingType": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:EnergySchedulingType",
+            "fields": {
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "StaticVarCompensator": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:StaticVarCompensator",
+            "fields": {
+                "capacitiveRating": {
+                    "label": "cim:StaticVarCompensator.capacitiveRating",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "inductiveRating": {
+                    "label": "cim:StaticVarCompensator.inductiveRating",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "slope": {
+                    "label": "cim:StaticVarCompensator.slope",
+                    "data_type": "VoltagePerReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "sVCControlMode": {
+                    "label": "cim:StaticVarCompensator.sVCControlMode",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SVCControlMode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SVCControlMode."
+                },
+                "voltageSetPoint": {
+                    "label": "cim:StaticVarCompensator.voltageSetPoint",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "RegulatingControl": {
+                    "label": "cim:RegulatingCondEq.RegulatingControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PowerTransformer": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PowerTransformer",
+            "fields": {
+                "PowerTransformerEnd": {
+                    "label": "cim:PowerTransformer.PowerTransformerEnd",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#PowerTransformerEnd.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#PowerTransformerEnd."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PowerTransformerEnd": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PowerTransformerEnd",
+            "fields": {
+                "PowerTransformer": {
+                    "label": "cim:PowerTransformerEnd.PowerTransformer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "b": {
+                    "label": "cim:PowerTransformerEnd.b",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "connectionKind": {
+                    "label": "cim:PowerTransformerEnd.connectionKind",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#WindingConnection.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#WindingConnection."
+                },
+                "ratedS": {
+                    "label": "cim:PowerTransformerEnd.ratedS",
+                    "data_type": "ApparentPower",
+                    "data_type_prim": "Float"
+                },
+                "g": {
+                    "label": "cim:PowerTransformerEnd.g",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                },
+                "ratedU": {
+                    "label": "cim:PowerTransformerEnd.ratedU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "r": {
+                    "label": "cim:PowerTransformerEnd.r",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "x": {
+                    "label": "cim:PowerTransformerEnd.x",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "BaseVoltage": {
+                    "label": "cim:TransformerEnd.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "PhaseTapChanger": {
+                    "label": "cim:TransformerEnd.PhaseTapChanger",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#PhaseTapChanger.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#PhaseTapChanger."
+                },
+                "RatioTapChanger": {
+                    "label": "cim:TransformerEnd.RatioTapChanger",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RatioTapChanger.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RatioTapChanger."
+                },
+                "Terminal": {
+                    "label": "cim:TransformerEnd.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "endNumber": {
+                    "label": "cim:TransformerEnd.endNumber",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "TapChangerControl": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:TapChangerControl",
+            "fields": {
+                "TapChanger": {
+                    "label": "cim:TapChangerControl.TapChanger",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#TapChanger.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#TapChanger."
+                },
+                "RegulationSchedule": {
+                    "label": "cim:RegulatingControl.RegulationSchedule",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegulationSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegulationSchedule."
+                },
+                "RegulatingCondEq": {
+                    "label": "cim:RegulatingControl.RegulatingCondEq",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegulatingCondEq.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegulatingCondEq."
+                },
+                "mode": {
+                    "label": "cim:RegulatingControl.mode",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegulatingControlModeKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegulatingControlModeKind."
+                },
+                "Terminal": {
+                    "label": "cim:RegulatingControl.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "RatioTapChanger": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:RatioTapChanger",
+            "fields": {
+                "stepVoltageIncrement": {
+                    "label": "cim:RatioTapChanger.stepVoltageIncrement",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "RatioTapChangerTable": {
+                    "label": "cim:RatioTapChanger.RatioTapChangerTable",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "TransformerEnd": {
+                    "label": "cim:RatioTapChanger.TransformerEnd",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "TapSchedules": {
+                    "label": "cim:TapChanger.TapSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#TapSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#TapSchedule."
+                },
+                "highStep": {
+                    "label": "cim:TapChanger.highStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "lowStep": {
+                    "label": "cim:TapChanger.lowStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "ltcFlag": {
+                    "label": "cim:TapChanger.ltcFlag",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "neutralStep": {
+                    "label": "cim:TapChanger.neutralStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "neutralU": {
+                    "label": "cim:TapChanger.neutralU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "normalStep": {
+                    "label": "cim:TapChanger.normalStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "TapChangerControl": {
+                    "label": "cim:TapChanger.TapChangerControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerLinear": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PhaseTapChangerLinear",
+            "fields": {
+                "stepPhaseShiftIncrement": {
+                    "label": "cim:PhaseTapChangerLinear.stepPhaseShiftIncrement",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "xMax": {
+                    "label": "cim:PhaseTapChangerLinear.xMax",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "xMin": {
+                    "label": "cim:PhaseTapChangerLinear.xMin",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "TransformerEnd": {
+                    "label": "cim:PhaseTapChanger.TransformerEnd",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "TapSchedules": {
+                    "label": "cim:TapChanger.TapSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#TapSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#TapSchedule."
+                },
+                "highStep": {
+                    "label": "cim:TapChanger.highStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "lowStep": {
+                    "label": "cim:TapChanger.lowStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "ltcFlag": {
+                    "label": "cim:TapChanger.ltcFlag",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "neutralStep": {
+                    "label": "cim:TapChanger.neutralStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "neutralU": {
+                    "label": "cim:TapChanger.neutralU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "normalStep": {
+                    "label": "cim:TapChanger.normalStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "TapChangerControl": {
+                    "label": "cim:TapChanger.TapChangerControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerAsymmetrical": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PhaseTapChangerAsymmetrical",
+            "fields": {
+                "windingConnectionAngle": {
+                    "label": "cim:PhaseTapChangerAsymmetrical.windingConnectionAngle",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "voltageStepIncrement": {
+                    "label": "cim:PhaseTapChangerNonLinear.voltageStepIncrement",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "xMax": {
+                    "label": "cim:PhaseTapChangerNonLinear.xMax",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "xMin": {
+                    "label": "cim:PhaseTapChangerNonLinear.xMin",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "TransformerEnd": {
+                    "label": "cim:PhaseTapChanger.TransformerEnd",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "TapSchedules": {
+                    "label": "cim:TapChanger.TapSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#TapSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#TapSchedule."
+                },
+                "highStep": {
+                    "label": "cim:TapChanger.highStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "lowStep": {
+                    "label": "cim:TapChanger.lowStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "ltcFlag": {
+                    "label": "cim:TapChanger.ltcFlag",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "neutralStep": {
+                    "label": "cim:TapChanger.neutralStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "neutralU": {
+                    "label": "cim:TapChanger.neutralU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "normalStep": {
+                    "label": "cim:TapChanger.normalStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "TapChangerControl": {
+                    "label": "cim:TapChanger.TapChangerControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerSymmetrical": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PhaseTapChangerSymmetrical",
+            "fields": {
+                "voltageStepIncrement": {
+                    "label": "cim:PhaseTapChangerNonLinear.voltageStepIncrement",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "xMax": {
+                    "label": "cim:PhaseTapChangerNonLinear.xMax",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "xMin": {
+                    "label": "cim:PhaseTapChangerNonLinear.xMin",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "TransformerEnd": {
+                    "label": "cim:PhaseTapChanger.TransformerEnd",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "TapSchedules": {
+                    "label": "cim:TapChanger.TapSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#TapSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#TapSchedule."
+                },
+                "highStep": {
+                    "label": "cim:TapChanger.highStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "lowStep": {
+                    "label": "cim:TapChanger.lowStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "ltcFlag": {
+                    "label": "cim:TapChanger.ltcFlag",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "neutralStep": {
+                    "label": "cim:TapChanger.neutralStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "neutralU": {
+                    "label": "cim:TapChanger.neutralU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "normalStep": {
+                    "label": "cim:TapChanger.normalStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "TapChangerControl": {
+                    "label": "cim:TapChanger.TapChangerControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerTabular": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PhaseTapChangerTabular",
+            "fields": {
+                "PhaseTapChangerTable": {
+                    "label": "cim:PhaseTapChangerTabular.PhaseTapChangerTable",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "TransformerEnd": {
+                    "label": "cim:PhaseTapChanger.TransformerEnd",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "TapSchedules": {
+                    "label": "cim:TapChanger.TapSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#TapSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#TapSchedule."
+                },
+                "highStep": {
+                    "label": "cim:TapChanger.highStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "lowStep": {
+                    "label": "cim:TapChanger.lowStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "ltcFlag": {
+                    "label": "cim:TapChanger.ltcFlag",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "neutralStep": {
+                    "label": "cim:TapChanger.neutralStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "neutralU": {
+                    "label": "cim:TapChanger.neutralU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "normalStep": {
+                    "label": "cim:TapChanger.normalStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "TapChangerControl": {
+                    "label": "cim:TapChanger.TapChangerControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerTablePoint": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PhaseTapChangerTablePoint",
+            "fields": {
+                "PhaseTapChangerTable": {
+                    "label": "cim:PhaseTapChangerTablePoint.PhaseTapChangerTable",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "angle": {
+                    "label": "cim:PhaseTapChangerTablePoint.angle",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "b": {
+                    "label": "cim:TapChangerTablePoint.b",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "g": {
+                    "label": "cim:TapChangerTablePoint.g",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "r": {
+                    "label": "cim:TapChangerTablePoint.r",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "ratio": {
+                    "label": "cim:TapChangerTablePoint.ratio",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "step": {
+                    "label": "cim:TapChangerTablePoint.step",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "x": {
+                    "label": "cim:TapChangerTablePoint.x",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                }
+            }
+        },
+        "RatioTapChangerTable": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:RatioTapChangerTable",
+            "fields": {
+                "RatioTapChanger": {
+                    "label": "cim:RatioTapChangerTable.RatioTapChanger",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RatioTapChanger.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RatioTapChanger."
+                },
+                "RatioTapChangerTablePoint": {
+                    "label": "cim:RatioTapChangerTable.RatioTapChangerTablePoint",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RatioTapChangerTablePoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RatioTapChangerTablePoint."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "RatioTapChangerTablePoint": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:RatioTapChangerTablePoint",
+            "fields": {
+                "RatioTapChangerTable": {
+                    "label": "cim:RatioTapChangerTablePoint.RatioTapChangerTable",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "b": {
+                    "label": "cim:TapChangerTablePoint.b",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "g": {
+                    "label": "cim:TapChangerTablePoint.g",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "r": {
+                    "label": "cim:TapChangerTablePoint.r",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "ratio": {
+                    "label": "cim:TapChangerTablePoint.ratio",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "step": {
+                    "label": "cim:TapChangerTablePoint.step",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "x": {
+                    "label": "cim:TapChangerTablePoint.x",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                }
+            }
+        },
+        "LinearShuntCompensator": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:LinearShuntCompensator",
+            "fields": {
+                "bPerSection": {
+                    "label": "cim:LinearShuntCompensator.bPerSection",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "gPerSection": {
+                    "label": "cim:LinearShuntCompensator.gPerSection",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                },
+                "aVRDelay": {
+                    "label": "cim:ShuntCompensator.aVRDelay",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "grounded": {
+                    "label": "cim:ShuntCompensator.grounded",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "maximumSections": {
+                    "label": "cim:ShuntCompensator.maximumSections",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "nomU": {
+                    "label": "cim:ShuntCompensator.nomU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "normalSections": {
+                    "label": "cim:ShuntCompensator.normalSections",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "voltageSensitivity": {
+                    "label": "cim:ShuntCompensator.voltageSensitivity",
+                    "data_type": "VoltagePerReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "RegulatingControl": {
+                    "label": "cim:RegulatingCondEq.RegulatingControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "NonlinearShuntCompensator": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:NonlinearShuntCompensator",
+            "fields": {
+                "NonlinearShuntCompensatorPoints": {
+                    "label": "cim:NonlinearShuntCompensator.NonlinearShuntCompensatorPoints",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#NonlinearShuntCompensatorPoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#NonlinearShuntCompensatorPoint."
+                },
+                "aVRDelay": {
+                    "label": "cim:ShuntCompensator.aVRDelay",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "grounded": {
+                    "label": "cim:ShuntCompensator.grounded",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "maximumSections": {
+                    "label": "cim:ShuntCompensator.maximumSections",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "nomU": {
+                    "label": "cim:ShuntCompensator.nomU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "normalSections": {
+                    "label": "cim:ShuntCompensator.normalSections",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "voltageSensitivity": {
+                    "label": "cim:ShuntCompensator.voltageSensitivity",
+                    "data_type": "VoltagePerReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "RegulatingControl": {
+                    "label": "cim:RegulatingCondEq.RegulatingControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "NonlinearShuntCompensatorPoint": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:NonlinearShuntCompensatorPoint",
+            "fields": {
+                "NonlinearShuntCompensator": {
+                    "label": "cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "b": {
+                    "label": "cim:NonlinearShuntCompensatorPoint.b",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "g": {
+                    "label": "cim:NonlinearShuntCompensatorPoint.g",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                },
+                "sectionNumber": {
+                    "label": "cim:NonlinearShuntCompensatorPoint.sectionNumber",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                }
+            }
+        },
+        "EquivalentBranch": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:EquivalentBranch",
+            "fields": {
+                "r": {
+                    "label": "cim:EquivalentBranch.r",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "r21": {
+                    "label": "cim:EquivalentBranch.r21",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "x": {
+                    "label": "cim:EquivalentBranch.x",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "x21": {
+                    "label": "cim:EquivalentBranch.x21",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "EquivalentNetwork": {
+                    "label": "cim:EquivalentEquipment.EquivalentNetwork",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EquivalentInjection": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:EquivalentInjection",
+            "fields": {
+                "maxP": {
+                    "label": "cim:EquivalentInjection.maxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "maxQ": {
+                    "label": "cim:EquivalentInjection.maxQ",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "minP": {
+                    "label": "cim:EquivalentInjection.minP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minQ": {
+                    "label": "cim:EquivalentInjection.minQ",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "regulationCapability": {
+                    "label": "cim:EquivalentInjection.regulationCapability",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "ReactiveCapabilityCurve": {
+                    "label": "cim:EquivalentInjection.ReactiveCapabilityCurve",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquivalentNetwork": {
+                    "label": "cim:EquivalentEquipment.EquivalentNetwork",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SeriesCompensator": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SeriesCompensator",
+            "fields": {
+                "r": {
+                    "label": "cim:SeriesCompensator.r",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "x": {
+                    "label": "cim:SeriesCompensator.x",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "MeasurementValueSource": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:MeasurementValueSource",
+            "fields": {}
+        },
+        "PetersenCoil": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PetersenCoil",
+            "fields": {
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ReactiveCapabilityCurve": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ReactiveCapabilityCurve",
+            "fields": {
+                "EquivalentInjection": {
+                    "label": "cim:ReactiveCapabilityCurve.EquivalentInjection",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#EquivalentInjection.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#EquivalentInjection."
+                },
+                "InitiallyUsedBySynchronousMachines": {
+                    "label": "cim:ReactiveCapabilityCurve.InitiallyUsedBySynchronousMachines",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SynchronousMachine.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SynchronousMachine."
+                },
+                "curveStyle": {
+                    "label": "cim:Curve.curveStyle",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#CurveStyle.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#CurveStyle."
+                },
+                "xUnit": {
+                    "label": "cim:Curve.xUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "y1Unit": {
+                    "label": "cim:Curve.y1Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "y2Unit": {
+                    "label": "cim:Curve.y2Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "CurveDatas": {
+                    "label": "cim:Curve.CurveDatas",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#CurveData.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#CurveData."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "CurveData": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:CurveData",
+            "fields": {
+                "Curve": {
+                    "label": "cim:CurveData.Curve",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "xvalue": {
+                    "label": "cim:CurveData.xvalue",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "y1value": {
+                    "label": "cim:CurveData.y1value",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "y2value": {
+                    "label": "cim:CurveData.y2value",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                }
+            }
+        },
+        "FullModel": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:FullModel",
+            "fields": {}
+        },
+        "Cut": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Cut",
+            "fields": {
+                "ACLineSegment": {
+                    "label": "cim:Cut.ACLineSegment",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "lengthFromTerminal1": {
+                    "label": "cim:Cut.lengthFromTerminal1",
+                    "data_type": "Length",
+                    "data_type_prim": "Float"
+                },
+                "normalOpen": {
+                    "label": "cim:Switch.normalOpen",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "ratedCurrent": {
+                    "label": "cim:Switch.ratedCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "retained": {
+                    "label": "cim:Switch.retained",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "SwitchSchedules": {
+                    "label": "cim:Switch.SwitchSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SwitchSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SwitchSchedule."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "CogenerationPlant": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:CogenerationPlant",
+            "fields": {
+                "ThermalGeneratingUnits": {
+                    "label": "cim:CogenerationPlant.ThermalGeneratingUnits",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ThermalGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ThermalGeneratingUnit."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SolarPowerPlant": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SolarPowerPlant",
+            "fields": {}
+        },
+        "DCSeriesDevice": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCSeriesDevice",
+            "fields": {
+                "inductance": {
+                    "label": "cim:DCSeriesDevice.inductance",
+                    "data_type": "Inductance",
+                    "data_type_prim": "Float"
+                },
+                "resistance": {
+                    "label": "cim:DCSeriesDevice.resistance",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "ratedUdc": {
+                    "label": "cim:DCConductingEquipment.ratedUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "DCTerminals": {
+                    "label": "cim:DCConductingEquipment.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCTerminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "VsCapabilityCurve": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:VsCapabilityCurve",
+            "fields": {
+                "VsConverterDCSides": {
+                    "label": "cim:VsCapabilityCurve.VsConverterDCSides",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#VsConverter.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#VsConverter."
+                },
+                "curveStyle": {
+                    "label": "cim:Curve.curveStyle",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#CurveStyle.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#CurveStyle."
+                },
+                "xUnit": {
+                    "label": "cim:Curve.xUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "y1Unit": {
+                    "label": "cim:Curve.y1Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "y2Unit": {
+                    "label": "cim:Curve.y2Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "CurveDatas": {
+                    "label": "cim:Curve.CurveDatas",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#CurveData.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#CurveData."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SwitchSchedule": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SwitchSchedule",
+            "fields": {
+                "Switch": {
+                    "label": "cim:SwitchSchedule.Switch",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DayType": {
+                    "label": "cim:SeasonDayTypeSchedule.DayType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Season": {
+                    "label": "cim:SeasonDayTypeSchedule.Season",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "TimePoints": {
+                    "label": "cim:RegularIntervalSchedule.TimePoints",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegularTimePoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegularTimePoint."
+                },
+                "timeStep": {
+                    "label": "cim:RegularIntervalSchedule.timeStep",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "endTime": {
+                    "label": "cim:RegularIntervalSchedule.endTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "startTime": {
+                    "label": "cim:BasicIntervalSchedule.startTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "value1Unit": {
+                    "label": "cim:BasicIntervalSchedule.value1Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "value2Unit": {
+                    "label": "cim:BasicIntervalSchedule.value2Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ApparentPowerLimit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ApparentPowerLimit",
+            "fields": {
+                "normalValue": {
+                    "label": "cim:ApparentPowerLimit.normalValue",
+                    "data_type": "ApparentPower",
+                    "data_type_prim": "Float"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:OperationalLimit.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitType": {
+                    "label": "cim:OperationalLimit.OperationalLimitType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Line": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Line",
+            "fields": {
+                "Region": {
+                    "label": "cim:Line.Region",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Equipments": {
+                    "label": "cim:EquipmentContainer.Equipments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Equipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Equipment."
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:ConnectivityNodeContainer.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SurgeArrester": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SurgeArrester",
+            "fields": {
+                "Terminal": {
+                    "label": "cim:AuxiliaryEquipment.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "WindPowerPlant": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:WindPowerPlant",
+            "fields": {}
+        },
+        "WaveTrap": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:WaveTrap",
+            "fields": {
+                "Terminal": {
+                    "label": "cim:AuxiliaryEquipment.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SubLoadArea": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SubLoadArea",
+            "fields": {
+                "LoadArea": {
+                    "label": "cim:SubLoadArea.LoadArea",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "LoadGroups": {
+                    "label": "cim:SubLoadArea.LoadGroups",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#LoadGroup.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#LoadGroup."
+                },
+                "ControlArea": {
+                    "label": "cim:EnergyArea.ControlArea",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlArea.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlArea."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PowerElectronicsConnection": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PowerElectronicsConnection",
+            "fields": {
+                "maxQ": {
+                    "label": "cim:PowerElectronicsConnection.maxQ",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "minQ": {
+                    "label": "cim:PowerElectronicsConnection.minQ",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedS": {
+                    "label": "cim:PowerElectronicsConnection.ratedS",
+                    "data_type": "ApparentPower",
+                    "data_type_prim": "Float"
+                },
+                "ratedU": {
+                    "label": "cim:PowerElectronicsConnection.ratedU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "PowerElectronicsUnit": {
+                    "label": "cim:PowerElectronicsConnection.PowerElectronicsUnit",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "RegulatingControl": {
+                    "label": "cim:RegulatingCondEq.RegulatingControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "GroundDisconnector": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:GroundDisconnector",
+            "fields": {
+                "normalOpen": {
+                    "label": "cim:Switch.normalOpen",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "ratedCurrent": {
+                    "label": "cim:Switch.ratedCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "retained": {
+                    "label": "cim:Switch.retained",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "SwitchSchedules": {
+                    "label": "cim:Switch.SwitchSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SwitchSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SwitchSchedule."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "FossilFuel": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:FossilFuel",
+            "fields": {
+                "fossilFuelType": {
+                    "label": "cim:FossilFuel.fossilFuelType",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#FuelType.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#FuelType."
+                },
+                "ThermalGeneratingUnit": {
+                    "label": "cim:FossilFuel.ThermalGeneratingUnit",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "RegulationSchedule": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:RegulationSchedule",
+            "fields": {
+                "RegulatingControl": {
+                    "label": "cim:RegulationSchedule.RegulatingControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DayType": {
+                    "label": "cim:SeasonDayTypeSchedule.DayType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Season": {
+                    "label": "cim:SeasonDayTypeSchedule.Season",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "TimePoints": {
+                    "label": "cim:RegularIntervalSchedule.TimePoints",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegularTimePoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegularTimePoint."
+                },
+                "timeStep": {
+                    "label": "cim:RegularIntervalSchedule.timeStep",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "endTime": {
+                    "label": "cim:RegularIntervalSchedule.endTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "startTime": {
+                    "label": "cim:BasicIntervalSchedule.startTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "value1Unit": {
+                    "label": "cim:BasicIntervalSchedule.value1Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "value2Unit": {
+                    "label": "cim:BasicIntervalSchedule.value2Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerTable": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PhaseTapChangerTable",
+            "fields": {
+                "PhaseTapChangerTablePoint": {
+                    "label": "cim:PhaseTapChangerTable.PhaseTapChangerTablePoint",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#PhaseTapChangerTablePoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#PhaseTapChangerTablePoint."
+                },
+                "PhaseTapChangerTabular": {
+                    "label": "cim:PhaseTapChangerTable.PhaseTapChangerTabular",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#PhaseTapChangerTabular.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#PhaseTapChangerTabular."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EquivalentNetwork": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:EquivalentNetwork",
+            "fields": {
+                "EquivalentEquipments": {
+                    "label": "cim:EquivalentNetwork.EquivalentEquipments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#EquivalentEquipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#EquivalentEquipment."
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:ConnectivityNodeContainer.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "BusNameMarker": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:BusNameMarker",
+            "fields": {
+                "Terminal": {
+                    "label": "cim:BusNameMarker.Terminal",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ACDCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ACDCTerminal."
+                },
+                "priority": {
+                    "label": "cim:BusNameMarker.priority",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "ReportingGroup": {
+                    "label": "cim:BusNameMarker.ReportingGroup",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "CAESPlant": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:CAESPlant",
+            "fields": {
+                "ThermalGeneratingUnit": {
+                    "label": "cim:CAESPlant.ThermalGeneratingUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ThermalGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ThermalGeneratingUnit."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "TapSchedule": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:TapSchedule",
+            "fields": {
+                "TapChanger": {
+                    "label": "cim:TapSchedule.TapChanger",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DayType": {
+                    "label": "cim:SeasonDayTypeSchedule.DayType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Season": {
+                    "label": "cim:SeasonDayTypeSchedule.Season",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "TimePoints": {
+                    "label": "cim:RegularIntervalSchedule.TimePoints",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegularTimePoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegularTimePoint."
+                },
+                "timeStep": {
+                    "label": "cim:RegularIntervalSchedule.timeStep",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "endTime": {
+                    "label": "cim:RegularIntervalSchedule.endTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "startTime": {
+                    "label": "cim:BasicIntervalSchedule.startTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "value1Unit": {
+                    "label": "cim:BasicIntervalSchedule.value1Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "value2Unit": {
+                    "label": "cim:BasicIntervalSchedule.value2Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "HydroPowerPlant": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:HydroPowerPlant",
+            "fields": {
+                "HydroGeneratingUnits": {
+                    "label": "cim:HydroPowerPlant.HydroGeneratingUnits",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#HydroGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#HydroGeneratingUnit."
+                },
+                "hydroPlantStorageType": {
+                    "label": "cim:HydroPowerPlant.hydroPlantStorageType",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#HydroPlantStorageKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#HydroPlantStorageKind."
+                },
+                "HydroPumps": {
+                    "label": "cim:HydroPowerPlant.HydroPumps",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#HydroPump.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#HydroPump."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "FaultIndicator": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:FaultIndicator",
+            "fields": {
+                "Terminal": {
+                    "label": "cim:AuxiliaryEquipment.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PowerElectronicsWindUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PowerElectronicsWindUnit",
+            "fields": {
+                "PowerElectronicsConnection": {
+                    "label": "cim:PowerElectronicsUnit.PowerElectronicsConnection",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#PowerElectronicsConnection.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#PowerElectronicsConnection."
+                },
+                "maxP": {
+                    "label": "cim:PowerElectronicsUnit.maxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minP": {
+                    "label": "cim:PowerElectronicsUnit.minP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "RegularTimePoint": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:RegularTimePoint",
+            "fields": {
+                "sequenceNumber": {
+                    "label": "cim:RegularTimePoint.sequenceNumber",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "value1": {
+                    "label": "cim:RegularTimePoint.value1",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "value2": {
+                    "label": "cim:RegularTimePoint.value2",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "IntervalSchedule": {
+                    "label": "cim:RegularTimePoint.IntervalSchedule",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                }
+            }
+        },
+        "Fuse": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Fuse",
+            "fields": {
+                "normalOpen": {
+                    "label": "cim:Switch.normalOpen",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "ratedCurrent": {
+                    "label": "cim:Switch.ratedCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "retained": {
+                    "label": "cim:Switch.retained",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "SwitchSchedules": {
+                    "label": "cim:Switch.SwitchSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SwitchSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SwitchSchedule."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DayType": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DayType",
+            "fields": {
+                "SeasonDayTypeSchedules": {
+                    "label": "cim:DayType.SeasonDayTypeSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SeasonDayTypeSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SeasonDayTypeSchedule."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ControlAreaGeneratingUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ControlAreaGeneratingUnit",
+            "fields": {
+                "ControlArea": {
+                    "label": "cim:ControlAreaGeneratingUnit.ControlArea",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "GeneratingUnit": {
+                    "label": "cim:ControlAreaGeneratingUnit.GeneratingUnit",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCGround": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCGround",
+            "fields": {
+                "inductance": {
+                    "label": "cim:DCGround.inductance",
+                    "data_type": "Inductance",
+                    "data_type_prim": "Float"
+                },
+                "r": {
+                    "label": "cim:DCGround.r",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "ratedUdc": {
+                    "label": "cim:DCConductingEquipment.ratedUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "DCTerminals": {
+                    "label": "cim:DCConductingEquipment.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCTerminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Jumper": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Jumper",
+            "fields": {
+                "normalOpen": {
+                    "label": "cim:Switch.normalOpen",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "ratedCurrent": {
+                    "label": "cim:Switch.ratedCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "retained": {
+                    "label": "cim:Switch.retained",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "SwitchSchedules": {
+                    "label": "cim:Switch.SwitchSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SwitchSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SwitchSchedule."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ConformLoadGroup": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ConformLoadGroup",
+            "fields": {
+                "ConformLoadSchedules": {
+                    "label": "cim:ConformLoadGroup.ConformLoadSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConformLoadSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConformLoadSchedule."
+                },
+                "EnergyConsumers": {
+                    "label": "cim:ConformLoadGroup.EnergyConsumers",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConformLoad.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConformLoad."
+                },
+                "SubLoadArea": {
+                    "label": "cim:LoadGroup.SubLoadArea",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhotoVoltaicUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PhotoVoltaicUnit",
+            "fields": {
+                "PowerElectronicsConnection": {
+                    "label": "cim:PowerElectronicsUnit.PowerElectronicsConnection",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#PowerElectronicsConnection.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#PowerElectronicsConnection."
+                },
+                "maxP": {
+                    "label": "cim:PowerElectronicsUnit.maxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minP": {
+                    "label": "cim:PowerElectronicsUnit.minP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EquivalentShunt": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:EquivalentShunt",
+            "fields": {
+                "b": {
+                    "label": "cim:EquivalentShunt.b",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "g": {
+                    "label": "cim:EquivalentShunt.g",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                },
+                "EquivalentNetwork": {
+                    "label": "cim:EquivalentEquipment.EquivalentNetwork",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ReportingGroup": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ReportingGroup",
+            "fields": {
+                "BusNameMarker": {
+                    "label": "cim:ReportingGroup.BusNameMarker",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#BusNameMarker.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#BusNameMarker."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ActivePowerLimit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ActivePowerLimit",
+            "fields": {
+                "normalValue": {
+                    "label": "cim:ActivePowerLimit.normalValue",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:OperationalLimit.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitType": {
+                    "label": "cim:OperationalLimit.OperationalLimitType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Clamp": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Clamp",
+            "fields": {
+                "ACLineSegment": {
+                    "label": "cim:Clamp.ACLineSegment",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "lengthFromTerminal1": {
+                    "label": "cim:Clamp.lengthFromTerminal1",
+                    "data_type": "Length",
+                    "data_type_prim": "Float"
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCDisconnector": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCDisconnector",
+            "fields": {
+                "ratedUdc": {
+                    "label": "cim:DCConductingEquipment.ratedUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "DCTerminals": {
+                    "label": "cim:DCConductingEquipment.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCTerminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCBreaker": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCBreaker",
+            "fields": {
+                "ratedUdc": {
+                    "label": "cim:DCConductingEquipment.ratedUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "DCTerminals": {
+                    "label": "cim:DCConductingEquipment.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCTerminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "NonConformLoadGroup": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:NonConformLoadGroup",
+            "fields": {
+                "EnergyConsumers": {
+                    "label": "cim:NonConformLoadGroup.EnergyConsumers",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#NonConformLoad.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#NonConformLoad."
+                },
+                "NonConformLoadSchedules": {
+                    "label": "cim:NonConformLoadGroup.NonConformLoadSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#NonConformLoadSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#NonConformLoadSchedule."
+                },
+                "SubLoadArea": {
+                    "label": "cim:LoadGroup.SubLoadArea",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "LoadResponseCharacteristic": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:LoadResponseCharacteristic",
+            "fields": {
+                "EnergyConsumer": {
+                    "label": "cim:LoadResponseCharacteristic.EnergyConsumer",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#EnergyConsumer.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#EnergyConsumer."
+                },
+                "exponentModel": {
+                    "label": "cim:LoadResponseCharacteristic.exponentModel",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "pConstantCurrent": {
+                    "label": "cim:LoadResponseCharacteristic.pConstantCurrent",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "pConstantImpedance": {
+                    "label": "cim:LoadResponseCharacteristic.pConstantImpedance",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "pConstantPower": {
+                    "label": "cim:LoadResponseCharacteristic.pConstantPower",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "pFrequencyExponent": {
+                    "label": "cim:LoadResponseCharacteristic.pFrequencyExponent",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "pVoltageExponent": {
+                    "label": "cim:LoadResponseCharacteristic.pVoltageExponent",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "qConstantCurrent": {
+                    "label": "cim:LoadResponseCharacteristic.qConstantCurrent",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "qConstantImpedance": {
+                    "label": "cim:LoadResponseCharacteristic.qConstantImpedance",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "qConstantPower": {
+                    "label": "cim:LoadResponseCharacteristic.qConstantPower",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "qFrequencyExponent": {
+                    "label": "cim:LoadResponseCharacteristic.qFrequencyExponent",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "qVoltageExponent": {
+                    "label": "cim:LoadResponseCharacteristic.qVoltageExponent",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PotentialTransformer": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PotentialTransformer",
+            "fields": {
+                "Terminal": {
+                    "label": "cim:AuxiliaryEquipment.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "CombinedCyclePlant": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:CombinedCyclePlant",
+            "fields": {
+                "ThermalGeneratingUnits": {
+                    "label": "cim:CombinedCyclePlant.ThermalGeneratingUnits",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ThermalGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ThermalGeneratingUnit."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Junction": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Junction",
+            "fields": {
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Season": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Season",
+            "fields": {
+                "endDate": {
+                    "label": "cim:Season.endDate",
+                    "data_type": "MonthDay",
+                    "data_type_prim": "MonthDay"
+                },
+                "startDate": {
+                    "label": "cim:Season.startDate",
+                    "data_type": "MonthDay",
+                    "data_type_prim": "MonthDay"
+                },
+                "SeasonDayTypeSchedules": {
+                    "label": "cim:Season.SeasonDayTypeSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SeasonDayTypeSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SeasonDayTypeSchedule."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DisconnectingCircuitBreaker": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DisconnectingCircuitBreaker",
+            "fields": {
+                "normalOpen": {
+                    "label": "cim:Switch.normalOpen",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "ratedCurrent": {
+                    "label": "cim:Switch.ratedCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "retained": {
+                    "label": "cim:Switch.retained",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "SwitchSchedules": {
+                    "label": "cim:Switch.SwitchSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SwitchSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SwitchSchedule."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "CurrentTransformer": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:CurrentTransformer",
+            "fields": {
+                "Terminal": {
+                    "label": "cim:AuxiliaryEquipment.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "NonConformLoadSchedule": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:NonConformLoadSchedule",
+            "fields": {
+                "NonConformLoadGroup": {
+                    "label": "cim:NonConformLoadSchedule.NonConformLoadGroup",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DayType": {
+                    "label": "cim:SeasonDayTypeSchedule.DayType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Season": {
+                    "label": "cim:SeasonDayTypeSchedule.Season",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "TimePoints": {
+                    "label": "cim:RegularIntervalSchedule.TimePoints",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegularTimePoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegularTimePoint."
+                },
+                "timeStep": {
+                    "label": "cim:RegularIntervalSchedule.timeStep",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "endTime": {
+                    "label": "cim:RegularIntervalSchedule.endTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "startTime": {
+                    "label": "cim:BasicIntervalSchedule.startTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "value1Unit": {
+                    "label": "cim:BasicIntervalSchedule.value1Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "value2Unit": {
+                    "label": "cim:BasicIntervalSchedule.value2Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ConformLoadSchedule": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ConformLoadSchedule",
+            "fields": {
+                "ConformLoadGroup": {
+                    "label": "cim:ConformLoadSchedule.ConformLoadGroup",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DayType": {
+                    "label": "cim:SeasonDayTypeSchedule.DayType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Season": {
+                    "label": "cim:SeasonDayTypeSchedule.Season",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "TimePoints": {
+                    "label": "cim:RegularIntervalSchedule.TimePoints",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegularTimePoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RegularTimePoint."
+                },
+                "timeStep": {
+                    "label": "cim:RegularIntervalSchedule.timeStep",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "endTime": {
+                    "label": "cim:RegularIntervalSchedule.endTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "startTime": {
+                    "label": "cim:BasicIntervalSchedule.startTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "value1Unit": {
+                    "label": "cim:BasicIntervalSchedule.value1Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "value2Unit": {
+                    "label": "cim:BasicIntervalSchedule.value2Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "GrossToNetActivePowerCurve": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:GrossToNetActivePowerCurve",
+            "fields": {
+                "GeneratingUnit": {
+                    "label": "cim:GrossToNetActivePowerCurve.GeneratingUnit",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "curveStyle": {
+                    "label": "cim:Curve.curveStyle",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#CurveStyle.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#CurveStyle."
+                },
+                "xUnit": {
+                    "label": "cim:Curve.xUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "y1Unit": {
+                    "label": "cim:Curve.y1Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "y2Unit": {
+                    "label": "cim:Curve.y2Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "CurveDatas": {
+                    "label": "cim:Curve.CurveDatas",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#CurveData.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#CurveData."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "LoadArea": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:LoadArea",
+            "fields": {
+                "SubLoadAreas": {
+                    "label": "cim:LoadArea.SubLoadAreas",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SubLoadArea.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SubLoadArea."
+                },
+                "ControlArea": {
+                    "label": "cim:EnergyArea.ControlArea",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlArea.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ControlArea."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "HydroPump": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:HydroPump",
+            "fields": {
+                "HydroPowerPlant": {
+                    "label": "cim:HydroPump.HydroPowerPlant",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "RotatingMachine": {
+                    "label": "cim:HydroPump.RotatingMachine",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCSwitch": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCSwitch",
+            "fields": {
+                "ratedUdc": {
+                    "label": "cim:DCConductingEquipment.ratedUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "DCTerminals": {
+                    "label": "cim:DCConductingEquipment.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCTerminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Ground": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Ground",
+            "fields": {
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCChopper": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCChopper",
+            "fields": {
+                "ratedUdc": {
+                    "label": "cim:DCConductingEquipment.ratedUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "DCTerminals": {
+                    "label": "cim:DCConductingEquipment.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCTerminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCBusbar": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCBusbar",
+            "fields": {
+                "ratedUdc": {
+                    "label": "cim:DCConductingEquipment.ratedUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "DCTerminals": {
+                    "label": "cim:DCConductingEquipment.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCTerminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCShunt": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCShunt",
+            "fields": {
+                "capacitance": {
+                    "label": "cim:DCShunt.capacitance",
+                    "data_type": "Capacitance",
+                    "data_type_prim": "Float"
+                },
+                "resistance": {
+                    "label": "cim:DCShunt.resistance",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "ratedUdc": {
+                    "label": "cim:DCConductingEquipment.ratedUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "DCTerminals": {
+                    "label": "cim:DCConductingEquipment.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCTerminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PostLineSensor": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PostLineSensor",
+            "fields": {
+                "Terminal": {
+                    "label": "cim:AuxiliaryEquipment.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "BatteryUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:BatteryUnit",
+            "fields": {
+                "ratedE": {
+                    "label": "cim:BatteryUnit.ratedE",
+                    "data_type": "RealEnergy",
+                    "data_type_prim": "Float"
+                },
+                "PowerElectronicsConnection": {
+                    "label": "cim:PowerElectronicsUnit.PowerElectronicsConnection",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#PowerElectronicsConnection.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#PowerElectronicsConnection."
+                },
+                "maxP": {
+                    "label": "cim:PowerElectronicsUnit.maxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minP": {
+                    "label": "cim:PowerElectronicsUnit.minP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "GroundingImpedance": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:GroundingImpedance",
+            "fields": {
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normallyInService": {
+                    "label": "cim:Equipment.normallyInService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OperationalLimitSet."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        }
+    },
+    "eq_bd": {
+        "ConnectivityNode": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ConnectivityNode",
+            "fields": {
+                "BoundaryPoint": {
+                    "label": "cim:ConnectivityNode.BoundaryPoint",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100-European#BoundaryPoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100-European#BoundaryPoint."
+                },
+                "Terminals": {
+                    "label": "cim:ConnectivityNode.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "ConnectivityNodeContainer": {
+                    "label": "cim:ConnectivityNode.ConnectivityNodeContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "BaseVoltage": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:BaseVoltage",
+            "fields": {
+                "nominalVoltage": {
+                    "label": "cim:BaseVoltage.nominalVoltage",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "VoltageLevel": {
+                    "label": "cim:BaseVoltage.VoltageLevel",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#VoltageLevel.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#VoltageLevel."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Terminal": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Terminal",
+            "fields": {
+                "ConductingEquipment": {
+                    "label": "cim:Terminal.ConductingEquipment",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ConnectivityNode": {
+                    "label": "cim:Terminal.ConnectivityNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EnergySource": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:EnergySource",
+            "fields": {}
+        },
+        "EnergySchedulingType": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:EnergySchedulingType",
+            "fields": {
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "FullModel": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:FullModel",
+            "fields": {}
+        },
+        "BoundaryPoint": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "eu:BoundaryPoint",
+            "fields": {
+                "fromEndIsoCode": {
+                    "label": "cim:BoundaryPoint.fromEndIsoCode",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "fromEndName": {
+                    "label": "cim:BoundaryPoint.fromEndName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "fromEndNameTso": {
+                    "label": "cim:BoundaryPoint.fromEndNameTso",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "toEndIsoCode": {
+                    "label": "cim:BoundaryPoint.toEndIsoCode",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "toEndName": {
+                    "label": "cim:BoundaryPoint.toEndName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "toEndNameTso": {
+                    "label": "cim:BoundaryPoint.toEndNameTso",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "isDirectCurrent": {
+                    "label": "cim:BoundaryPoint.isDirectCurrent",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "isExcludedFromAreaInterchange": {
+                    "label": "cim:BoundaryPoint.isExcludedFromAreaInterchange",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "ConnectivityNode": {
+                    "label": "cim:BoundaryPoint.ConnectivityNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Line": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Line",
+            "fields": {
+                "Region": {
+                    "label": "cim:Line.Region",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Equipments": {
+                    "label": "cim:EquipmentContainer.Equipments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Equipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Equipment."
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:ConnectivityNodeContainer.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SubGeographicalRegion": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SubGeographicalRegion",
+            "fields": {
+                "Region": {
+                    "label": "cim:SubGeographicalRegion.Region",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Lines": {
+                    "label": "cim:SubGeographicalRegion.Lines",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Line.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Line."
+                },
+                "Substations": {
+                    "label": "cim:SubGeographicalRegion.Substations",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Substation.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Substation."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "GeographicalRegion": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:GeographicalRegion",
+            "fields": {
+                "Regions": {
+                    "label": "cim:GeographicalRegion.Regions",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SubGeographicalRegion.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SubGeographicalRegion."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        }
+    },
+    "op": {
+        "Analog": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Analog",
+            "fields": {
+                "positiveFlowIn": {
+                    "label": "cim:Analog.positiveFlowIn",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "AnalogValues": {
+                    "label": "cim:Analog.AnalogValues",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#AnalogValue.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#AnalogValue."
+                },
+                "LimitSets": {
+                    "label": "cim:Analog.LimitSets",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#AnalogLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#AnalogLimitSet."
+                },
+                "Terminal": {
+                    "label": "cim:Measurement.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "measurementType": {
+                    "label": "cim:Measurement.measurementType",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "phases": {
+                    "label": "cim:Measurement.phases",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#PhaseCode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#PhaseCode."
+                },
+                "unitMultiplier": {
+                    "label": "cim:Measurement.unitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier."
+                },
+                "unitSymbol": {
+                    "label": "cim:Measurement.unitSymbol",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "PowerSystemResource": {
+                    "label": "cim:Measurement.PowerSystemResource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "AnalogValue": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:AnalogValue",
+            "fields": {
+                "Analog": {
+                    "label": "cim:AnalogValue.Analog",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "AnalogControl": {
+                    "label": "cim:AnalogValue.AnalogControl",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#AnalogControl.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#AnalogControl."
+                },
+                "timeStamp": {
+                    "label": "cim:MeasurementValue.timeStamp",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "sensorAccuracy": {
+                    "label": "cim:MeasurementValue.sensorAccuracy",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "MeasurementValueQuality": {
+                    "label": "cim:MeasurementValue.MeasurementValueQuality",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#MeasurementValueQuality.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#MeasurementValueQuality."
+                },
+                "MeasurementValueSource": {
+                    "label": "cim:MeasurementValue.MeasurementValueSource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Discrete": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Discrete",
+            "fields": {
+                "DiscreteValues": {
+                    "label": "cim:Discrete.DiscreteValues",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DiscreteValue.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DiscreteValue."
+                },
+                "ValueAliasSet": {
+                    "label": "cim:Discrete.ValueAliasSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminal": {
+                    "label": "cim:Measurement.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "measurementType": {
+                    "label": "cim:Measurement.measurementType",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "phases": {
+                    "label": "cim:Measurement.phases",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#PhaseCode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#PhaseCode."
+                },
+                "unitMultiplier": {
+                    "label": "cim:Measurement.unitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier."
+                },
+                "unitSymbol": {
+                    "label": "cim:Measurement.unitSymbol",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "PowerSystemResource": {
+                    "label": "cim:Measurement.PowerSystemResource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DiscreteValue": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DiscreteValue",
+            "fields": {
+                "Command": {
+                    "label": "cim:DiscreteValue.Command",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Command.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Command."
+                },
+                "Discrete": {
+                    "label": "cim:DiscreteValue.Discrete",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "timeStamp": {
+                    "label": "cim:MeasurementValue.timeStamp",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "sensorAccuracy": {
+                    "label": "cim:MeasurementValue.sensorAccuracy",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "MeasurementValueQuality": {
+                    "label": "cim:MeasurementValue.MeasurementValueQuality",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#MeasurementValueQuality.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#MeasurementValueQuality."
+                },
+                "MeasurementValueSource": {
+                    "label": "cim:MeasurementValue.MeasurementValueSource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "FullModel": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:FullModel",
+            "fields": {}
+        },
+        "AccumulatorLimit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:AccumulatorLimit",
+            "fields": {
+                "value": {
+                    "label": "cim:AccumulatorLimit.value",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "LimitSet": {
+                    "label": "cim:AccumulatorLimit.LimitSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "StringMeasurement": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:StringMeasurement",
+            "fields": {
+                "StringMeasurementValues": {
+                    "label": "cim:StringMeasurement.StringMeasurementValues",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#StringMeasurementValue.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#StringMeasurementValue."
+                },
+                "Terminal": {
+                    "label": "cim:Measurement.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "measurementType": {
+                    "label": "cim:Measurement.measurementType",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "phases": {
+                    "label": "cim:Measurement.phases",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#PhaseCode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#PhaseCode."
+                },
+                "unitMultiplier": {
+                    "label": "cim:Measurement.unitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier."
+                },
+                "unitSymbol": {
+                    "label": "cim:Measurement.unitSymbol",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "PowerSystemResource": {
+                    "label": "cim:Measurement.PowerSystemResource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Command": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Command",
+            "fields": {
+                "normalValue": {
+                    "label": "cim:Command.normalValue",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "value": {
+                    "label": "cim:Command.value",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "ValueAliasSet": {
+                    "label": "cim:Command.ValueAliasSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DiscreteValue": {
+                    "label": "cim:Command.DiscreteValue",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "controlType": {
+                    "label": "cim:Control.controlType",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "operationInProgress": {
+                    "label": "cim:Control.operationInProgress",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "timeStamp": {
+                    "label": "cim:Control.timeStamp",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "unitMultiplier": {
+                    "label": "cim:Control.unitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier."
+                },
+                "unitSymbol": {
+                    "label": "cim:Control.unitSymbol",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "PowerSystemResource": {
+                    "label": "cim:Control.PowerSystemResource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "MeasurementValueSource": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:MeasurementValueSource",
+            "fields": {
+                "MeasurementValues": {
+                    "label": "cim:MeasurementValueSource.MeasurementValues",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#MeasurementValue.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#MeasurementValue."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "AccumulatorLimitSet": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:AccumulatorLimitSet",
+            "fields": {
+                "Measurements": {
+                    "label": "cim:AccumulatorLimitSet.Measurements",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Limits": {
+                    "label": "cim:AccumulatorLimitSet.Limits",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#AccumulatorLimit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#AccumulatorLimit."
+                },
+                "isPercentageLimits": {
+                    "label": "cim:LimitSet.isPercentageLimits",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "AnalogLimitSet": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:AnalogLimitSet",
+            "fields": {
+                "Measurements": {
+                    "label": "cim:AnalogLimitSet.Measurements",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Limits": {
+                    "label": "cim:AnalogLimitSet.Limits",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#AnalogLimit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#AnalogLimit."
+                },
+                "isPercentageLimits": {
+                    "label": "cim:LimitSet.isPercentageLimits",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "AccumulatorReset": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:AccumulatorReset",
+            "fields": {
+                "AccumulatorValue": {
+                    "label": "cim:AccumulatorReset.AccumulatorValue",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "controlType": {
+                    "label": "cim:Control.controlType",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "operationInProgress": {
+                    "label": "cim:Control.operationInProgress",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "timeStamp": {
+                    "label": "cim:Control.timeStamp",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "unitMultiplier": {
+                    "label": "cim:Control.unitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier."
+                },
+                "unitSymbol": {
+                    "label": "cim:Control.unitSymbol",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "PowerSystemResource": {
+                    "label": "cim:Control.PowerSystemResource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Accumulator": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Accumulator",
+            "fields": {
+                "AccumulatorValues": {
+                    "label": "cim:Accumulator.AccumulatorValues",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#AccumulatorValue.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#AccumulatorValue."
+                },
+                "LimitSets": {
+                    "label": "cim:Accumulator.LimitSets",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#AccumulatorLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#AccumulatorLimitSet."
+                },
+                "Terminal": {
+                    "label": "cim:Measurement.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "measurementType": {
+                    "label": "cim:Measurement.measurementType",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "phases": {
+                    "label": "cim:Measurement.phases",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#PhaseCode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#PhaseCode."
+                },
+                "unitMultiplier": {
+                    "label": "cim:Measurement.unitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier."
+                },
+                "unitSymbol": {
+                    "label": "cim:Measurement.unitSymbol",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "PowerSystemResource": {
+                    "label": "cim:Measurement.PowerSystemResource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SetPoint": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SetPoint",
+            "fields": {
+                "normalValue": {
+                    "label": "cim:SetPoint.normalValue",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "value": {
+                    "label": "cim:SetPoint.value",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "maxValue": {
+                    "label": "cim:AnalogControl.maxValue",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "minValue": {
+                    "label": "cim:AnalogControl.minValue",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "AnalogValue": {
+                    "label": "cim:AnalogControl.AnalogValue",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "controlType": {
+                    "label": "cim:Control.controlType",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "operationInProgress": {
+                    "label": "cim:Control.operationInProgress",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "timeStamp": {
+                    "label": "cim:Control.timeStamp",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "unitMultiplier": {
+                    "label": "cim:Control.unitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier."
+                },
+                "unitSymbol": {
+                    "label": "cim:Control.unitSymbol",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "PowerSystemResource": {
+                    "label": "cim:Control.PowerSystemResource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "AccumulatorValue": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:AccumulatorValue",
+            "fields": {
+                "Accumulator": {
+                    "label": "cim:AccumulatorValue.Accumulator",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "AccumulatorReset": {
+                    "label": "cim:AccumulatorValue.AccumulatorReset",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#AccumulatorReset.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#AccumulatorReset."
+                },
+                "timeStamp": {
+                    "label": "cim:MeasurementValue.timeStamp",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "sensorAccuracy": {
+                    "label": "cim:MeasurementValue.sensorAccuracy",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "MeasurementValueQuality": {
+                    "label": "cim:MeasurementValue.MeasurementValueQuality",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#MeasurementValueQuality.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#MeasurementValueQuality."
+                },
+                "MeasurementValueSource": {
+                    "label": "cim:MeasurementValue.MeasurementValueSource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "MeasurementValueQuality": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:MeasurementValueQuality",
+            "fields": {
+                "MeasurementValue": {
+                    "label": "cim:MeasurementValueQuality.MeasurementValue",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "badReference": {
+                    "label": "cim:Quality61850.badReference",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "estimatorReplaced": {
+                    "label": "cim:Quality61850.estimatorReplaced",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "failure": {
+                    "label": "cim:Quality61850.failure",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "oldData": {
+                    "label": "cim:Quality61850.oldData",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "operatorBlocked": {
+                    "label": "cim:Quality61850.operatorBlocked",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "oscillatory": {
+                    "label": "cim:Quality61850.oscillatory",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "outOfRange": {
+                    "label": "cim:Quality61850.outOfRange",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "overFlow": {
+                    "label": "cim:Quality61850.overFlow",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "source": {
+                    "label": "cim:Quality61850.source",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Source.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Source."
+                },
+                "suspect": {
+                    "label": "cim:Quality61850.suspect",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "test": {
+                    "label": "cim:Quality61850.test",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "validity": {
+                    "label": "cim:Quality61850.validity",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Validity.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Validity."
+                }
+            }
+        },
+        "StringMeasurementValue": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:StringMeasurementValue",
+            "fields": {
+                "StringMeasurement": {
+                    "label": "cim:StringMeasurementValue.StringMeasurement",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "timeStamp": {
+                    "label": "cim:MeasurementValue.timeStamp",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "sensorAccuracy": {
+                    "label": "cim:MeasurementValue.sensorAccuracy",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "MeasurementValueQuality": {
+                    "label": "cim:MeasurementValue.MeasurementValueQuality",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#MeasurementValueQuality.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#MeasurementValueQuality."
+                },
+                "MeasurementValueSource": {
+                    "label": "cim:MeasurementValue.MeasurementValueSource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "AnalogLimit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:AnalogLimit",
+            "fields": {
+                "value": {
+                    "label": "cim:AnalogLimit.value",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "LimitSet": {
+                    "label": "cim:AnalogLimit.LimitSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ValueAliasSet": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ValueAliasSet",
+            "fields": {
+                "Commands": {
+                    "label": "cim:ValueAliasSet.Commands",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Command.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Command."
+                },
+                "Discretes": {
+                    "label": "cim:ValueAliasSet.Discretes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Discrete.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Discrete."
+                },
+                "RaiseLowerCommands": {
+                    "label": "cim:ValueAliasSet.RaiseLowerCommands",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#RaiseLowerCommand.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#RaiseLowerCommand."
+                },
+                "Values": {
+                    "label": "cim:ValueAliasSet.Values",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ValueToAlias.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ValueToAlias."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "RaiseLowerCommand": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:RaiseLowerCommand",
+            "fields": {
+                "ValueAliasSet": {
+                    "label": "cim:RaiseLowerCommand.ValueAliasSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "maxValue": {
+                    "label": "cim:AnalogControl.maxValue",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "minValue": {
+                    "label": "cim:AnalogControl.minValue",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "AnalogValue": {
+                    "label": "cim:AnalogControl.AnalogValue",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "controlType": {
+                    "label": "cim:Control.controlType",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "operationInProgress": {
+                    "label": "cim:Control.operationInProgress",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "timeStamp": {
+                    "label": "cim:Control.timeStamp",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "unitMultiplier": {
+                    "label": "cim:Control.unitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier."
+                },
+                "unitSymbol": {
+                    "label": "cim:Control.unitSymbol",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitSymbol."
+                },
+                "PowerSystemResource": {
+                    "label": "cim:Control.PowerSystemResource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ValueToAlias": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ValueToAlias",
+            "fields": {
+                "ValueAliasSet": {
+                    "label": "cim:ValueToAlias.ValueAliasSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "value": {
+                    "label": "cim:ValueToAlias.value",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        }
+    },
+    "sc": {
+        "PowerTransformer": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:PowerTransformer",
+            "fields": {
+                "beforeShCircuitHighestOperatingCurrent": {
+                    "label": "cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "beforeShCircuitHighestOperatingVoltage": {
+                    "label": "cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "beforeShortCircuitAnglePf": {
+                    "label": "cim:PowerTransformer.beforeShortCircuitAnglePf",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "highSideMinOperatingU": {
+                    "label": "cim:PowerTransformer.highSideMinOperatingU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "isPartOfGeneratorUnit": {
+                    "label": "cim:PowerTransformer.isPartOfGeneratorUnit",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "operationalValuesConsidered": {
+                    "label": "cim:PowerTransformer.operationalValuesConsidered",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PowerTransformerEnd": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:PowerTransformerEnd",
+            "fields": {
+                "b0": {
+                    "label": "cim:PowerTransformerEnd.b0",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "phaseAngleClock": {
+                    "label": "cim:PowerTransformerEnd.phaseAngleClock",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "g0": {
+                    "label": "cim:PowerTransformerEnd.g0",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                },
+                "r0": {
+                    "label": "cim:PowerTransformerEnd.r0",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "x0": {
+                    "label": "cim:PowerTransformerEnd.x0",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "rground": {
+                    "label": "cim:TransformerEnd.rground",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "grounded": {
+                    "label": "cim:TransformerEnd.grounded",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "xground": {
+                    "label": "cim:TransformerEnd.xground",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SynchronousMachine": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:SynchronousMachine",
+            "fields": {
+                "earthing": {
+                    "label": "cim:SynchronousMachine.earthing",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "earthingStarPointR": {
+                    "label": "cim:SynchronousMachine.earthingStarPointR",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "earthingStarPointX": {
+                    "label": "cim:SynchronousMachine.earthingStarPointX",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "ikk": {
+                    "label": "cim:SynchronousMachine.ikk",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "mu": {
+                    "label": "cim:SynchronousMachine.mu",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "x0": {
+                    "label": "cim:SynchronousMachine.x0",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "r0": {
+                    "label": "cim:SynchronousMachine.r0",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "x2": {
+                    "label": "cim:SynchronousMachine.x2",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "r2": {
+                    "label": "cim:SynchronousMachine.r2",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "r": {
+                    "label": "cim:SynchronousMachine.r",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "satDirectSubtransX": {
+                    "label": "cim:SynchronousMachine.satDirectSubtransX",
+                    "data_type": "PU",
+                    "data_type_prim": "Float"
+                },
+                "satDirectSyncX": {
+                    "label": "cim:SynchronousMachine.satDirectSyncX",
+                    "data_type": "PU",
+                    "data_type_prim": "Float"
+                },
+                "satDirectTransX": {
+                    "label": "cim:SynchronousMachine.satDirectTransX",
+                    "data_type": "PU",
+                    "data_type_prim": "Float"
+                },
+                "shortCircuitRotorType": {
+                    "label": "cim:SynchronousMachine.shortCircuitRotorType",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ShortCircuitRotorKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ShortCircuitRotorKind."
+                },
+                "voltageRegulationRange": {
+                    "label": "cim:SynchronousMachine.voltageRegulationRange",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "AsynchronousMachine": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:AsynchronousMachine",
+            "fields": {
+                "converterFedDrive": {
+                    "label": "cim:AsynchronousMachine.converterFedDrive",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "efficiency": {
+                    "label": "cim:AsynchronousMachine.efficiency",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "iaIrRatio": {
+                    "label": "cim:AsynchronousMachine.iaIrRatio",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "polePairNumber": {
+                    "label": "cim:AsynchronousMachine.polePairNumber",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "ratedMechanicalPower": {
+                    "label": "cim:AsynchronousMachine.ratedMechanicalPower",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "reversible": {
+                    "label": "cim:AsynchronousMachine.reversible",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "rxLockedRotorRatio": {
+                    "label": "cim:AsynchronousMachine.rxLockedRotorRatio",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ACLineSegment": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ACLineSegment",
+            "fields": {
+                "b0ch": {
+                    "label": "cim:ACLineSegment.b0ch",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "g0ch": {
+                    "label": "cim:ACLineSegment.g0ch",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                },
+                "r0": {
+                    "label": "cim:ACLineSegment.r0",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "shortCircuitEndTemperature": {
+                    "label": "cim:ACLineSegment.shortCircuitEndTemperature",
+                    "data_type": "Temperature",
+                    "data_type_prim": "Float"
+                },
+                "x0": {
+                    "label": "cim:ACLineSegment.x0",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PetersenCoil": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:PetersenCoil",
+            "fields": {
+                "mode": {
+                    "label": "cim:PetersenCoil.mode",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#PetersenCoilModeKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#PetersenCoilModeKind."
+                },
+                "nominalU": {
+                    "label": "cim:PetersenCoil.nominalU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "offsetCurrent": {
+                    "label": "cim:PetersenCoil.offsetCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "positionCurrent": {
+                    "label": "cim:PetersenCoil.positionCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "xGroundMax": {
+                    "label": "cim:PetersenCoil.xGroundMax",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "xGroundMin": {
+                    "label": "cim:PetersenCoil.xGroundMin",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "xGroundNominal": {
+                    "label": "cim:PetersenCoil.xGroundNominal",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "r": {
+                    "label": "cim:EarthFaultCompensator.r",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ExternalNetworkInjection": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ExternalNetworkInjection",
+            "fields": {
+                "ikSecond": {
+                    "label": "cim:ExternalNetworkInjection.ikSecond",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "maxInitialSymShCCurrent": {
+                    "label": "cim:ExternalNetworkInjection.maxInitialSymShCCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "maxR0ToX0Ratio": {
+                    "label": "cim:ExternalNetworkInjection.maxR0ToX0Ratio",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "maxR1ToX1Ratio": {
+                    "label": "cim:ExternalNetworkInjection.maxR1ToX1Ratio",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "maxZ0ToZ1Ratio": {
+                    "label": "cim:ExternalNetworkInjection.maxZ0ToZ1Ratio",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "minInitialSymShCCurrent": {
+                    "label": "cim:ExternalNetworkInjection.minInitialSymShCCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "minR0ToX0Ratio": {
+                    "label": "cim:ExternalNetworkInjection.minR0ToX0Ratio",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "minR1ToX1Ratio": {
+                    "label": "cim:ExternalNetworkInjection.minR1ToX1Ratio",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "minZ0ToZ1Ratio": {
+                    "label": "cim:ExternalNetworkInjection.minZ0ToZ1Ratio",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "voltageFactor": {
+                    "label": "cim:ExternalNetworkInjection.voltageFactor",
+                    "data_type": "PU",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EquivalentBranch": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:EquivalentBranch",
+            "fields": {
+                "negativeR12": {
+                    "label": "cim:EquivalentBranch.negativeR12",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "negativeR21": {
+                    "label": "cim:EquivalentBranch.negativeR21",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "negativeX12": {
+                    "label": "cim:EquivalentBranch.negativeX12",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "negativeX21": {
+                    "label": "cim:EquivalentBranch.negativeX21",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "positiveR12": {
+                    "label": "cim:EquivalentBranch.positiveR12",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "positiveR21": {
+                    "label": "cim:EquivalentBranch.positiveR21",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "positiveX12": {
+                    "label": "cim:EquivalentBranch.positiveX12",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "positiveX21": {
+                    "label": "cim:EquivalentBranch.positiveX21",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "zeroR12": {
+                    "label": "cim:EquivalentBranch.zeroR12",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "zeroR21": {
+                    "label": "cim:EquivalentBranch.zeroR21",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "zeroX12": {
+                    "label": "cim:EquivalentBranch.zeroX12",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "zeroX21": {
+                    "label": "cim:EquivalentBranch.zeroX21",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EquivalentInjection": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:EquivalentInjection",
+            "fields": {
+                "r": {
+                    "label": "cim:EquivalentInjection.r",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "r0": {
+                    "label": "cim:EquivalentInjection.r0",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "r2": {
+                    "label": "cim:EquivalentInjection.r2",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "x": {
+                    "label": "cim:EquivalentInjection.x",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "x0": {
+                    "label": "cim:EquivalentInjection.x0",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "x2": {
+                    "label": "cim:EquivalentInjection.x2",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SeriesCompensator": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:SeriesCompensator",
+            "fields": {
+                "r0": {
+                    "label": "cim:SeriesCompensator.r0",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "x0": {
+                    "label": "cim:SeriesCompensator.x0",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "varistorPresent": {
+                    "label": "cim:SeriesCompensator.varistorPresent",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "varistorRatedCurrent": {
+                    "label": "cim:SeriesCompensator.varistorRatedCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "varistorVoltageThreshold": {
+                    "label": "cim:SeriesCompensator.varistorVoltageThreshold",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "FullModel": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:FullModel",
+            "fields": {}
+        },
+        "BusbarSection": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:BusbarSection",
+            "fields": {
+                "ipMax": {
+                    "label": "cim:BusbarSection.ipMax",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "NonlinearShuntCompensatorPoint": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:NonlinearShuntCompensatorPoint",
+            "fields": {
+                "b0": {
+                    "label": "cim:NonlinearShuntCompensatorPoint.b0",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "g0": {
+                    "label": "cim:NonlinearShuntCompensatorPoint.g0",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                }
+            }
+        },
+        "LinearShuntCompensator": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:LinearShuntCompensator",
+            "fields": {
+                "b0PerSection": {
+                    "label": "cim:LinearShuntCompensator.b0PerSection",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "g0PerSection": {
+                    "label": "cim:LinearShuntCompensator.g0PerSection",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EnergySource": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:EnergySource",
+            "fields": {
+                "r": {
+                    "label": "cim:EnergySource.r",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "r0": {
+                    "label": "cim:EnergySource.r0",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "rn": {
+                    "label": "cim:EnergySource.rn",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "x": {
+                    "label": "cim:EnergySource.x",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "x0": {
+                    "label": "cim:EnergySource.x0",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "xn": {
+                    "label": "cim:EnergySource.xn",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "MutualCoupling": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:MutualCoupling",
+            "fields": {
+                "b0ch": {
+                    "label": "cim:MutualCoupling.b0ch",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "distance11": {
+                    "label": "cim:MutualCoupling.distance11",
+                    "data_type": "Length",
+                    "data_type_prim": "Float"
+                },
+                "distance12": {
+                    "label": "cim:MutualCoupling.distance12",
+                    "data_type": "Length",
+                    "data_type_prim": "Float"
+                },
+                "distance21": {
+                    "label": "cim:MutualCoupling.distance21",
+                    "data_type": "Length",
+                    "data_type_prim": "Float"
+                },
+                "distance22": {
+                    "label": "cim:MutualCoupling.distance22",
+                    "data_type": "Length",
+                    "data_type_prim": "Float"
+                },
+                "g0ch": {
+                    "label": "cim:MutualCoupling.g0ch",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                },
+                "r0": {
+                    "label": "cim:MutualCoupling.r0",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "x0": {
+                    "label": "cim:MutualCoupling.x0",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "Second_Terminal": {
+                    "label": "cim:MutualCoupling.Second_Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "First_Terminal": {
+                    "label": "cim:MutualCoupling.First_Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "GroundingImpedance": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:GroundingImpedance",
+            "fields": {
+                "x": {
+                    "label": "cim:GroundingImpedance.x",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "r": {
+                    "label": "cim:EarthFaultCompensator.r",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        }
+    },
+    "ssh": {
+        "ControlArea": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ControlArea",
+            "fields": {
+                "netInterchange": {
+                    "label": "cim:ControlArea.netInterchange",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "pTolerance": {
+                    "label": "cim:ControlArea.pTolerance",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ExternalNetworkInjection": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ExternalNetworkInjection",
+            "fields": {
+                "referencePriority": {
+                    "label": "cim:ExternalNetworkInjection.referencePriority",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "p": {
+                    "label": "cim:ExternalNetworkInjection.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:ExternalNetworkInjection.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "controlEnabled": {
+                    "label": "cim:RegulatingCondEq.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Terminal": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:Terminal",
+            "fields": {
+                "connected": {
+                    "label": "cim:ACDCTerminal.connected",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCTerminal": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:DCTerminal",
+            "fields": {
+                "connected": {
+                    "label": "cim:ACDCTerminal.connected",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ACDCConverterDCTerminal": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ACDCConverterDCTerminal",
+            "fields": {
+                "connected": {
+                    "label": "cim:ACDCTerminal.connected",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "CsConverter": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:CsConverter",
+            "fields": {
+                "operatingMode": {
+                    "label": "cim:CsConverter.operatingMode",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#CsOperatingModeKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#CsOperatingModeKind."
+                },
+                "pPccControl": {
+                    "label": "cim:CsConverter.pPccControl",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#CsPpccControlKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#CsPpccControlKind."
+                },
+                "targetAlpha": {
+                    "label": "cim:CsConverter.targetAlpha",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "targetGamma": {
+                    "label": "cim:CsConverter.targetGamma",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "targetIdc": {
+                    "label": "cim:CsConverter.targetIdc",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "p": {
+                    "label": "cim:ACDCConverter.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:ACDCConverter.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "targetPpcc": {
+                    "label": "cim:ACDCConverter.targetPpcc",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "targetUdc": {
+                    "label": "cim:ACDCConverter.targetUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "VsConverter": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:VsConverter",
+            "fields": {
+                "droop": {
+                    "label": "cim:VsConverter.droop",
+                    "data_type": "PU",
+                    "data_type_prim": "Float"
+                },
+                "droopCompensation": {
+                    "label": "cim:VsConverter.droopCompensation",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "pPccControl": {
+                    "label": "cim:VsConverter.pPccControl",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#VsPpccControlKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#VsPpccControlKind."
+                },
+                "qPccControl": {
+                    "label": "cim:VsConverter.qPccControl",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#VsQpccControlKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#VsQpccControlKind."
+                },
+                "qShare": {
+                    "label": "cim:VsConverter.qShare",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "targetQpcc": {
+                    "label": "cim:VsConverter.targetQpcc",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "targetUpcc": {
+                    "label": "cim:VsConverter.targetUpcc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "targetPowerFactorPcc": {
+                    "label": "cim:VsConverter.targetPowerFactorPcc",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "targetPhasePcc": {
+                    "label": "cim:VsConverter.targetPhasePcc",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "targetPWMfactor": {
+                    "label": "cim:VsConverter.targetPWMfactor",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "p": {
+                    "label": "cim:ACDCConverter.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:ACDCConverter.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "targetPpcc": {
+                    "label": "cim:ACDCConverter.targetPpcc",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "targetUdc": {
+                    "label": "cim:ACDCConverter.targetUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Breaker": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:Breaker",
+            "fields": {
+                "open": {
+                    "label": "cim:Switch.open",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "locked": {
+                    "label": "cim:Switch.locked",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Disconnector": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:Disconnector",
+            "fields": {
+                "open": {
+                    "label": "cim:Switch.open",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "locked": {
+                    "label": "cim:Switch.locked",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Switch": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:Switch",
+            "fields": {
+                "open": {
+                    "label": "cim:Switch.open",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "locked": {
+                    "label": "cim:Switch.locked",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "LoadBreakSwitch": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:LoadBreakSwitch",
+            "fields": {
+                "open": {
+                    "label": "cim:Switch.open",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "locked": {
+                    "label": "cim:Switch.locked",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EnergyConsumer": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:EnergyConsumer",
+            "fields": {
+                "p": {
+                    "label": "cim:EnergyConsumer.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:EnergyConsumer.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ConformLoad": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ConformLoad",
+            "fields": {
+                "p": {
+                    "label": "cim:EnergyConsumer.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:EnergyConsumer.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "NonConformLoad": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:NonConformLoad",
+            "fields": {
+                "p": {
+                    "label": "cim:EnergyConsumer.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:EnergyConsumer.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "StationSupply": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:StationSupply",
+            "fields": {
+                "p": {
+                    "label": "cim:EnergyConsumer.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:EnergyConsumer.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "RegulatingControl": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:RegulatingControl",
+            "fields": {
+                "discrete": {
+                    "label": "cim:RegulatingControl.discrete",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "enabled": {
+                    "label": "cim:RegulatingControl.enabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "targetDeadband": {
+                    "label": "cim:RegulatingControl.targetDeadband",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "targetValue": {
+                    "label": "cim:RegulatingControl.targetValue",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "targetValueUnitMultiplier": {
+                    "label": "cim:RegulatingControl.targetValueUnitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier."
+                },
+                "maxAllowedTargetValue": {
+                    "label": "cim:RegulatingControl.maxAllowedTargetValue",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "minAllowedTargetValue": {
+                    "label": "cim:RegulatingControl.minAllowedTargetValue",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SynchronousMachine": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:SynchronousMachine",
+            "fields": {
+                "operatingMode": {
+                    "label": "cim:SynchronousMachine.operatingMode",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SynchronousMachineOperatingMode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SynchronousMachineOperatingMode."
+                },
+                "referencePriority": {
+                    "label": "cim:SynchronousMachine.referencePriority",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "p": {
+                    "label": "cim:RotatingMachine.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:RotatingMachine.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "controlEnabled": {
+                    "label": "cim:RegulatingCondEq.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "AsynchronousMachine": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:AsynchronousMachine",
+            "fields": {
+                "asynchronousMachineType": {
+                    "label": "cim:AsynchronousMachine.asynchronousMachineType",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#AsynchronousMachineKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#AsynchronousMachineKind."
+                },
+                "p": {
+                    "label": "cim:RotatingMachine.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:RotatingMachine.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "controlEnabled": {
+                    "label": "cim:RegulatingCondEq.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EnergySource": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:EnergySource",
+            "fields": {
+                "activePower": {
+                    "label": "cim:EnergySource.activePower",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "reactivePower": {
+                    "label": "cim:EnergySource.reactivePower",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "voltageAngle": {
+                    "label": "cim:EnergySource.voltageAngle",
+                    "data_type": "AngleRadians",
+                    "data_type_prim": "Float"
+                },
+                "voltageMagnitude": {
+                    "label": "cim:EnergySource.voltageMagnitude",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "StaticVarCompensator": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:StaticVarCompensator",
+            "fields": {
+                "q": {
+                    "label": "cim:StaticVarCompensator.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "controlEnabled": {
+                    "label": "cim:RegulatingCondEq.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "TapChangerControl": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:TapChangerControl",
+            "fields": {
+                "discrete": {
+                    "label": "cim:RegulatingControl.discrete",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "enabled": {
+                    "label": "cim:RegulatingControl.enabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "targetDeadband": {
+                    "label": "cim:RegulatingControl.targetDeadband",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "targetValue": {
+                    "label": "cim:RegulatingControl.targetValue",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "targetValueUnitMultiplier": {
+                    "label": "cim:RegulatingControl.targetValueUnitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#UnitMultiplier."
+                },
+                "maxAllowedTargetValue": {
+                    "label": "cim:RegulatingControl.maxAllowedTargetValue",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "minAllowedTargetValue": {
+                    "label": "cim:RegulatingControl.minAllowedTargetValue",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "RatioTapChanger": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:RatioTapChanger",
+            "fields": {
+                "controlEnabled": {
+                    "label": "cim:TapChanger.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "step": {
+                    "label": "cim:TapChanger.step",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerLinear": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:PhaseTapChangerLinear",
+            "fields": {
+                "controlEnabled": {
+                    "label": "cim:TapChanger.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "step": {
+                    "label": "cim:TapChanger.step",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerAsymmetrical": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:PhaseTapChangerAsymmetrical",
+            "fields": {
+                "controlEnabled": {
+                    "label": "cim:TapChanger.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "step": {
+                    "label": "cim:TapChanger.step",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerSymmetrical": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:PhaseTapChangerSymmetrical",
+            "fields": {
+                "controlEnabled": {
+                    "label": "cim:TapChanger.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "step": {
+                    "label": "cim:TapChanger.step",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerTabular": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:PhaseTapChangerTabular",
+            "fields": {
+                "controlEnabled": {
+                    "label": "cim:TapChanger.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "step": {
+                    "label": "cim:TapChanger.step",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "LinearShuntCompensator": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:LinearShuntCompensator",
+            "fields": {
+                "sections": {
+                    "label": "cim:ShuntCompensator.sections",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "controlEnabled": {
+                    "label": "cim:RegulatingCondEq.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "NonlinearShuntCompensator": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:NonlinearShuntCompensator",
+            "fields": {
+                "sections": {
+                    "label": "cim:ShuntCompensator.sections",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "controlEnabled": {
+                    "label": "cim:RegulatingCondEq.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EquivalentInjection": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:EquivalentInjection",
+            "fields": {
+                "regulationStatus": {
+                    "label": "cim:EquivalentInjection.regulationStatus",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "regulationTarget": {
+                    "label": "cim:EquivalentInjection.regulationTarget",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "p": {
+                    "label": "cim:EquivalentInjection.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:EquivalentInjection.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "GeneratingUnit": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:GeneratingUnit",
+            "fields": {
+                "normalPF": {
+                    "label": "cim:GeneratingUnit.normalPF",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "NuclearGeneratingUnit": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:NuclearGeneratingUnit",
+            "fields": {
+                "normalPF": {
+                    "label": "cim:GeneratingUnit.normalPF",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "HydroGeneratingUnit": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:HydroGeneratingUnit",
+            "fields": {
+                "normalPF": {
+                    "label": "cim:GeneratingUnit.normalPF",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ThermalGeneratingUnit": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ThermalGeneratingUnit",
+            "fields": {
+                "normalPF": {
+                    "label": "cim:GeneratingUnit.normalPF",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SolarGeneratingUnit": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:SolarGeneratingUnit",
+            "fields": {
+                "normalPF": {
+                    "label": "cim:GeneratingUnit.normalPF",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "WindGeneratingUnit": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:WindGeneratingUnit",
+            "fields": {
+                "normalPF": {
+                    "label": "cim:GeneratingUnit.normalPF",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "CurrentLimit": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:CurrentLimit",
+            "fields": {
+                "value": {
+                    "label": "cim:CurrentLimit.value",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "VoltageLimit": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:VoltageLimit",
+            "fields": {
+                "value": {
+                    "label": "cim:VoltageLimit.value",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "FullModel": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:FullModel",
+            "fields": {}
+        },
+        "Equipment": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Equipment",
+            "fields": {
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ApparentPowerLimit": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ApparentPowerLimit",
+            "fields": {
+                "value": {
+                    "label": "cim:ApparentPowerLimit.value",
+                    "data_type": "ApparentPower",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PowerElectronicsConnection": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:PowerElectronicsConnection",
+            "fields": {
+                "p": {
+                    "label": "cim:PowerElectronicsConnection.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:PowerElectronicsConnection.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "controlEnabled": {
+                    "label": "cim:RegulatingCondEq.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "GroundDisconnector": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:GroundDisconnector",
+            "fields": {
+                "open": {
+                    "label": "cim:Switch.open",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "locked": {
+                    "label": "cim:Switch.locked",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Fuse": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:Fuse",
+            "fields": {
+                "open": {
+                    "label": "cim:Switch.open",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "locked": {
+                    "label": "cim:Switch.locked",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Jumper": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:Jumper",
+            "fields": {
+                "open": {
+                    "label": "cim:Switch.open",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "locked": {
+                    "label": "cim:Switch.locked",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ActivePowerLimit": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ActivePowerLimit",
+            "fields": {
+                "value": {
+                    "label": "cim:ActivePowerLimit.value",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DisconnectingCircuitBreaker": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:DisconnectingCircuitBreaker",
+            "fields": {
+                "open": {
+                    "label": "cim:Switch.open",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "locked": {
+                    "label": "cim:Switch.locked",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "BatteryUnit": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:BatteryUnit",
+            "fields": {
+                "batteryState": {
+                    "label": "cim:BatteryUnit.batteryState",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#BatteryStateKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#BatteryStateKind."
+                },
+                "storedE": {
+                    "label": "cim:BatteryUnit.storedE",
+                    "data_type": "RealEnergy",
+                    "data_type_prim": "Float"
+                },
+                "inService": {
+                    "label": "cim:Equipment.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        }
+    },
+    "sv": {
+        "SvVoltage": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SvVoltage",
+            "fields": {
+                "angle": {
+                    "label": "cim:SvVoltage.angle",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "v": {
+                    "label": "cim:SvVoltage.v",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "TopologicalNode": {
+                    "label": "cim:SvVoltage.TopologicalNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                }
+            }
+        },
+        "SvPowerFlow": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SvPowerFlow",
+            "fields": {
+                "p": {
+                    "label": "cim:SvPowerFlow.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:SvPowerFlow.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "Terminal": {
+                    "label": "cim:SvPowerFlow.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                }
+            }
+        },
+        "SvShuntCompensatorSections": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SvShuntCompensatorSections",
+            "fields": {
+                "ShuntCompensator": {
+                    "label": "cim:SvShuntCompensatorSections.ShuntCompensator",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "sections": {
+                    "label": "cim:SvShuntCompensatorSections.sections",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                }
+            }
+        },
+        "SvTapStep": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SvTapStep",
+            "fields": {
+                "position": {
+                    "label": "cim:SvTapStep.position",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "TapChanger": {
+                    "label": "cim:SvTapStep.TapChanger",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                }
+            }
+        },
+        "FullModel": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:FullModel",
+            "fields": {}
+        },
+        "SvSwitch": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SvSwitch",
+            "fields": {
+                "open": {
+                    "label": "cim:SvSwitch.open",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "Switch": {
+                    "label": "cim:SvSwitch.Switch",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                }
+            }
+        },
+        "TopologicalIsland": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:TopologicalIsland",
+            "fields": {
+                "AngleRefTopologicalNode": {
+                    "label": "cim:TopologicalIsland.AngleRefTopologicalNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "TopologicalNodes": {
+                    "label": "cim:TopologicalIsland.TopologicalNodes",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SvStatus": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SvStatus",
+            "fields": {
+                "ConductingEquipment": {
+                    "label": "cim:SvStatus.ConductingEquipment",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "inService": {
+                    "label": "cim:SvStatus.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                }
+            }
+        },
+        "CsConverter": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:CsConverter",
+            "fields": {
+                "alpha": {
+                    "label": "cim:CsConverter.alpha",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "gamma": {
+                    "label": "cim:CsConverter.gamma",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "idc": {
+                    "label": "cim:ACDCConverter.idc",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "poleLossP": {
+                    "label": "cim:ACDCConverter.poleLossP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "uc": {
+                    "label": "cim:ACDCConverter.uc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "udc": {
+                    "label": "cim:ACDCConverter.udc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "SvStatus": {
+                    "label": "cim:ConductingEquipment.SvStatus",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SvStatus.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SvStatus."
+                }
+            }
+        },
+        "SvInjection": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SvInjection",
+            "fields": {
+                "pInjection": {
+                    "label": "cim:SvInjection.pInjection",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "qInjection": {
+                    "label": "cim:SvInjection.qInjection",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "TopologicalNode": {
+                    "label": "cim:SvInjection.TopologicalNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                }
+            }
+        },
+        "VsConverter": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:VsConverter",
+            "fields": {
+                "delta": {
+                    "label": "cim:VsConverter.delta",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "uv": {
+                    "label": "cim:VsConverter.uv",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "idc": {
+                    "label": "cim:ACDCConverter.idc",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "poleLossP": {
+                    "label": "cim:ACDCConverter.poleLossP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "uc": {
+                    "label": "cim:ACDCConverter.uc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "udc": {
+                    "label": "cim:ACDCConverter.udc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "SvStatus": {
+                    "label": "cim:ConductingEquipment.SvStatus",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#SvStatus.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#SvStatus."
+                }
+            }
+        },
+        "DCTopologicalIsland": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCTopologicalIsland",
+            "fields": {
+                "DCTopologicalNodes": {
+                    "label": "cim:DCTopologicalIsland.DCTopologicalNodes",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        }
+    },
+    "tp": {
+        "TopologicalNode": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:TopologicalNode",
+            "fields": {
+                "BaseVoltage": {
+                    "label": "cim:TopologicalNode.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:TopologicalNode.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#ConnectivityNode."
+                },
+                "ConnectivityNodeContainer": {
+                    "label": "cim:TopologicalNode.ConnectivityNodeContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminal": {
+                    "label": "cim:TopologicalNode.Terminal",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Terminal."
+                },
+                "ReportingGroup": {
+                    "label": "cim:TopologicalNode.ReportingGroup",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCTopologicalNode": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCTopologicalNode",
+            "fields": {
+                "DCTerminals": {
+                    "label": "cim:DCTopologicalNode.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCBaseTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCBaseTerminal."
+                },
+                "DCEquipmentContainer": {
+                    "label": "cim:DCTopologicalNode.DCEquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DCNodes": {
+                    "label": "cim:DCTopologicalNode.DCNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DCNode."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ConnectivityNode": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ConnectivityNode",
+            "fields": {
+                "TopologicalNode": {
+                    "label": "cim:ConnectivityNode.TopologicalNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                }
+            }
+        },
+        "Terminal": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:Terminal",
+            "fields": {
+                "TopologicalNode": {
+                    "label": "cim:Terminal.TopologicalNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCTerminal": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:DCTerminal",
+            "fields": {
+                "DCTopologicalNode": {
+                    "label": "cim:DCBaseTerminal.DCTopologicalNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ACDCConverterDCTerminal": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ACDCConverterDCTerminal",
+            "fields": {
+                "DCTopologicalNode": {
+                    "label": "cim:DCBaseTerminal.DCTopologicalNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "FullModel": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:FullModel",
+            "fields": {}
+        },
+        "DCNode": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:DCNode",
+            "fields": {
+                "DCTopologicalNode": {
+                    "label": "cim:DCNode.DCTopologicalNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "cim:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "cim:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        }
+    },
+    "dl": {
+        "Diagram": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Diagram",
+            "fields": {
+                "orientation": {
+                    "label": "cim:Diagram.orientation",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#OrientationKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#OrientationKind."
+                },
+                "x1InitialView": {
+                    "label": "cim:Diagram.x1InitialView",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "x2InitialView": {
+                    "label": "cim:Diagram.x2InitialView",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "y1InitialView": {
+                    "label": "cim:Diagram.y1InitialView",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "y2InitialView": {
+                    "label": "cim:Diagram.y2InitialView",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "DiagramElements": {
+                    "label": "cim:Diagram.DiagramElements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DiagramObject.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DiagramObject."
+                },
+                "DiagramStyle": {
+                    "label": "cim:Diagram.DiagramStyle",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DiagramObjects": {
+                    "label": "cim:IdentifiedObject.DiagramObjects",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DiagramObject.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DiagramObject."
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DiagramObject": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DiagramObject",
+            "fields": {
+                "Diagram": {
+                    "label": "cim:DiagramObject.Diagram",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "drawingOrder": {
+                    "label": "cim:DiagramObject.drawingOrder",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "isPolygon": {
+                    "label": "cim:DiagramObject.isPolygon",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "offsetX": {
+                    "label": "cim:DiagramObject.offsetX",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "offsetY": {
+                    "label": "cim:DiagramObject.offsetY",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "rotation": {
+                    "label": "cim:DiagramObject.rotation",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "IdentifiedObject": {
+                    "label": "cim:DiagramObject.IdentifiedObject",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DiagramObjectPoints": {
+                    "label": "cim:DiagramObject.DiagramObjectPoints",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DiagramObjectPoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DiagramObjectPoint."
+                },
+                "VisibilityLayers": {
+                    "label": "cim:DiagramObject.VisibilityLayers",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#VisibilityLayer.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#VisibilityLayer."
+                },
+                "DiagramObjectStyle": {
+                    "label": "cim:DiagramObject.DiagramObjectStyle",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DiagramObjects": {
+                    "label": "cim:IdentifiedObject.DiagramObjects",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#DiagramObject.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#DiagramObject."
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DiagramObjectPoint": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DiagramObjectPoint",
+            "fields": {
+                "DiagramObject": {
+                    "label": "cim:DiagramObjectPoint.DiagramObject",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DiagramObjectGluePoint": {
+                    "label": "cim:DiagramObjectPoint.DiagramObjectGluePoint",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "sequenceNumber": {
+                    "label": "cim:DiagramObjectPoint.sequenceNumber",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "xPosition": {
+                    "label": "cim:DiagramObjectPoint.xPosition",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "yPosition": {
+                    "label": "cim:DiagramObjectPoint.yPosition",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                },
+                "zPosition": {
+                    "label": "cim:DiagramObjectPoint.zPosition",
+                    "data_type": "Float",
+                    "data_type_prim": "Float"
+                }
+            }
+        }
+    },
+    "gl": {
+        "CoordinateSystem": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:CoordinateSystem",
+            "fields": {
+                "crsUrn": {
+                    "label": "cim:CoordinateSystem.crsUrn",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "Locations": {
+                    "label": "cim:CoordinateSystem.Locations",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#Location.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#Location."
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Location": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Location",
+            "fields": {
+                "CoordinateSystem": {
+                    "label": "cim:Location.CoordinateSystem",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "mainAddress": {
+                    "label": "cim:Location.mainAddress",
+                    "data_type": "StreetAddress",
+                    "data_type_prim": "StreetAddress"
+                },
+                "PowerSystemResources": {
+                    "label": "cim:Location.PowerSystemResources",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "PositionPoints": {
+                    "label": "cim:Location.PositionPoints",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/CIM100#PositionPoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/CIM100#PositionPoint."
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PositionPoint": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PositionPoint",
+            "fields": {
+                "Location": {
+                    "label": "cim:PositionPoint.Location",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "sequenceNumber": {
+                    "label": "cim:PositionPoint.sequenceNumber",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "xPosition": {
+                    "label": "cim:PositionPoint.xPosition",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "yPosition": {
+                    "label": "cim:PositionPoint.yPosition",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "zPosition": {
+                    "label": "cim:PositionPoint.zPosition",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        }
+    }
+}

--- a/pandapower/converter/cim/serialized_schemas/CIM16_4.2.13_schema.json
+++ b/pandapower/converter/cim/serialized_schemas/CIM16_4.2.13_schema.json
@@ -1,0 +1,11344 @@
+{
+    "eq": {
+        "ControlArea": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ControlArea",
+            "fields": {
+                "type": {
+                    "label": "cim:ControlArea.type",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaTypeKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaTypeKind."
+                },
+                "ControlAreaGeneratingUnit": {
+                    "label": "cim:ControlArea.ControlAreaGeneratingUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaGeneratingUnit."
+                },
+                "TieFlow": {
+                    "label": "cim:ControlArea.TieFlow",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TieFlow.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TieFlow."
+                },
+                "EnergyArea": {
+                    "label": "cim:ControlArea.EnergyArea",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "TieFlow": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:TieFlow",
+            "fields": {
+                "Terminal": {
+                    "label": "cim:TieFlow.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ControlArea": {
+                    "label": "cim:TieFlow.ControlArea",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "positiveFlowIn": {
+                    "label": "cim:TieFlow.positiveFlowIn",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                }
+            }
+        },
+        "ConnectivityNode": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ConnectivityNode",
+            "fields": {
+                "Terminals": {
+                    "label": "cim:ConnectivityNode.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "ConnectivityNodeContainer": {
+                    "label": "cim:ConnectivityNode.ConnectivityNodeContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Bay": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Bay",
+            "fields": {
+                "VoltageLevel": {
+                    "label": "cim:Bay.VoltageLevel",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Equipments": {
+                    "label": "cim:EquipmentContainer.Equipments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Equipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Equipment."
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:ConnectivityNodeContainer.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "BusbarSection": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:BusbarSection",
+            "fields": {
+                "ipMax": {
+                    "label": "cim:BusbarSection.ipMax",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Substation": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Substation",
+            "fields": {
+                "Region": {
+                    "label": "cim:Substation.Region",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "VoltageLevels": {
+                    "label": "cim:Substation.VoltageLevels",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#VoltageLevel.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#VoltageLevel."
+                },
+                "DCConverterUnit": {
+                    "label": "cim:Substation.DCConverterUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCConverterUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCConverterUnit."
+                },
+                "Equipments": {
+                    "label": "cim:EquipmentContainer.Equipments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Equipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Equipment."
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:ConnectivityNodeContainer.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "GeographicalRegion": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:GeographicalRegion",
+            "fields": {
+                "Regions": {
+                    "label": "cim:GeographicalRegion.Regions",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SubGeographicalRegion.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SubGeographicalRegion."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SubGeographicalRegion": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SubGeographicalRegion",
+            "fields": {
+                "Substations": {
+                    "label": "cim:SubGeographicalRegion.Substations",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Substation.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Substation."
+                },
+                "DCLines": {
+                    "label": "cim:SubGeographicalRegion.DCLines",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCLine.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCLine."
+                },
+                "Lines": {
+                    "label": "cim:SubGeographicalRegion.Lines",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Line.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Line."
+                },
+                "Region": {
+                    "label": "cim:SubGeographicalRegion.Region",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "VoltageLevel": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:VoltageLevel",
+            "fields": {
+                "Bays": {
+                    "label": "cim:VoltageLevel.Bays",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Bay.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Bay."
+                },
+                "BaseVoltage": {
+                    "label": "cim:VoltageLevel.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Substation": {
+                    "label": "cim:VoltageLevel.Substation",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "lowVoltageLimit": {
+                    "label": "cim:VoltageLevel.lowVoltageLimit",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "highVoltageLimit": {
+                    "label": "cim:VoltageLevel.highVoltageLimit",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "Equipments": {
+                    "label": "cim:EquipmentContainer.Equipments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Equipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Equipment."
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:ConnectivityNodeContainer.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "BaseVoltage": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:BaseVoltage",
+            "fields": {
+                "nominalVoltage": {
+                    "label": "cim:BaseVoltage.nominalVoltage",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "VoltageLevel": {
+                    "label": "cim:BaseVoltage.VoltageLevel",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#VoltageLevel.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#VoltageLevel."
+                },
+                "ConductingEquipment": {
+                    "label": "cim:BaseVoltage.ConductingEquipment",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConductingEquipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConductingEquipment."
+                },
+                "TransformerEnds": {
+                    "label": "cim:BaseVoltage.TransformerEnds",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TransformerEnd.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TransformerEnd."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ExternalNetworkInjection": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ExternalNetworkInjection",
+            "fields": {
+                "maxZ0ToZ1Ratio": {
+                    "label": "cim:ExternalNetworkInjection.maxZ0ToZ1Ratio",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "ikSecond": {
+                    "label": "cim:ExternalNetworkInjection.ikSecond",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "maxP": {
+                    "label": "cim:ExternalNetworkInjection.maxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "maxR1ToX1Ratio": {
+                    "label": "cim:ExternalNetworkInjection.maxR1ToX1Ratio",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "minQ": {
+                    "label": "cim:ExternalNetworkInjection.minQ",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "governorSCD": {
+                    "label": "cim:ExternalNetworkInjection.governorSCD",
+                    "data_type": "ActivePowerPerFrequency",
+                    "data_type_prim": "Float"
+                },
+                "minZ0ToZ1Ratio": {
+                    "label": "cim:ExternalNetworkInjection.minZ0ToZ1Ratio",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "voltageFactor": {
+                    "label": "cim:ExternalNetworkInjection.voltageFactor",
+                    "data_type": "PU",
+                    "data_type_prim": "Float"
+                },
+                "maxInitialSymShCCurrent": {
+                    "label": "cim:ExternalNetworkInjection.maxInitialSymShCCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "minP": {
+                    "label": "cim:ExternalNetworkInjection.minP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "maxQ": {
+                    "label": "cim:ExternalNetworkInjection.maxQ",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "maxR0ToX0Ratio": {
+                    "label": "cim:ExternalNetworkInjection.maxR0ToX0Ratio",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "minR0ToX0Ratio": {
+                    "label": "cim:ExternalNetworkInjection.minR0ToX0Ratio",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "minR1ToX1Ratio": {
+                    "label": "cim:ExternalNetworkInjection.minR1ToX1Ratio",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "minInitialSymShCCurrent": {
+                    "label": "cim:ExternalNetworkInjection.minInitialSymShCCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "RegulatingControl": {
+                    "label": "cim:RegulatingCondEq.RegulatingControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ACLineSegment": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ACLineSegment",
+            "fields": {
+                "shortCircuitEndTemperature": {
+                    "label": "cim:ACLineSegment.shortCircuitEndTemperature",
+                    "data_type": "Temperature",
+                    "data_type_prim": "Float"
+                },
+                "x": {
+                    "label": "cim:ACLineSegment.x",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "b0ch": {
+                    "label": "cim:ACLineSegment.b0ch",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "x0": {
+                    "label": "cim:ACLineSegment.x0",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "bch": {
+                    "label": "cim:ACLineSegment.bch",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "r0": {
+                    "label": "cim:ACLineSegment.r0",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "g0ch": {
+                    "label": "cim:ACLineSegment.g0ch",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                },
+                "gch": {
+                    "label": "cim:ACLineSegment.gch",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                },
+                "r": {
+                    "label": "cim:ACLineSegment.r",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "length": {
+                    "label": "cim:Conductor.length",
+                    "data_type": "Length",
+                    "data_type_prim": "Float"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Terminal": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Terminal",
+            "fields": {
+                "RegulatingControl": {
+                    "label": "cim:Terminal.RegulatingControl",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControl.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControl."
+                },
+                "ConverterDCSides": {
+                    "label": "cim:Terminal.ConverterDCSides",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ACDCConverter.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ACDCConverter."
+                },
+                "HasFirstMutualCoupling": {
+                    "label": "cim:Terminal.HasFirstMutualCoupling",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#MutualCoupling.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#MutualCoupling."
+                },
+                "HasSecondMutualCoupling": {
+                    "label": "cim:Terminal.HasSecondMutualCoupling",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#MutualCoupling.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#MutualCoupling."
+                },
+                "TieFlow": {
+                    "label": "cim:Terminal.TieFlow",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TieFlow.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TieFlow."
+                },
+                "TransformerEnd": {
+                    "label": "cim:Terminal.TransformerEnd",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TransformerEnd.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TransformerEnd."
+                },
+                "ConnectivityNode": {
+                    "label": "cim:Terminal.ConnectivityNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "phases": {
+                    "label": "cim:Terminal.phases",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode."
+                },
+                "ConductingEquipment": {
+                    "label": "cim:Terminal.ConductingEquipment",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "sequenceNumber": {
+                    "label": "cim:ACDCTerminal.sequenceNumber",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "Measurements": {
+                    "label": "cim:ACDCTerminal.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "BusNameMarker": {
+                    "label": "cim:ACDCTerminal.BusNameMarker",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:ACDCTerminal.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "OperationalLimitSet": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:OperationalLimitSet",
+            "fields": {
+                "Equipment": {
+                    "label": "cim:OperationalLimitSet.Equipment",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitValue": {
+                    "label": "cim:OperationalLimitSet.OperationalLimitValue",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimit."
+                },
+                "Terminal": {
+                    "label": "cim:OperationalLimitSet.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "OperationalLimitType": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:OperationalLimitType",
+            "fields": {
+                "OperationalLimit": {
+                    "label": "cim:OperationalLimitType.OperationalLimit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimit."
+                },
+                "limitType": {
+                    "label": "entsoe:OperationalLimitType.limitType",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#LimitTypeKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#LimitTypeKind."
+                },
+                "direction": {
+                    "label": "cim:OperationalLimitType.direction",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitDirectionKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitDirectionKind."
+                },
+                "acceptableDuration": {
+                    "label": "cim:OperationalLimitType.acceptableDuration",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "CurrentLimit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:CurrentLimit",
+            "fields": {
+                "value": {
+                    "label": "cim:CurrentLimit.value",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "OperationalLimitType": {
+                    "label": "cim:OperationalLimit.OperationalLimitType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:OperationalLimit.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "VoltageLimit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:VoltageLimit",
+            "fields": {
+                "value": {
+                    "label": "cim:VoltageLimit.value",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "OperationalLimitType": {
+                    "label": "cim:OperationalLimit.OperationalLimitType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:OperationalLimit.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCNode": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCNode",
+            "fields": {
+                "DCTerminals": {
+                    "label": "cim:DCNode.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCBaseTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCBaseTerminal."
+                },
+                "DCEquipmentContainer": {
+                    "label": "cim:DCNode.DCEquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCEquipmentContainer": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCEquipmentContainer",
+            "fields": {
+                "DCNodes": {
+                    "label": "cim:DCEquipmentContainer.DCNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCNode."
+                },
+                "Equipments": {
+                    "label": "cim:EquipmentContainer.Equipments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Equipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Equipment."
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:ConnectivityNodeContainer.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCLine": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCLine",
+            "fields": {
+                "Region": {
+                    "label": "cim:DCLine.Region",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DCNodes": {
+                    "label": "cim:DCEquipmentContainer.DCNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCNode."
+                },
+                "Equipments": {
+                    "label": "cim:EquipmentContainer.Equipments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Equipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Equipment."
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:ConnectivityNodeContainer.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCConverterUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCConverterUnit",
+            "fields": {
+                "operationMode": {
+                    "label": "cim:DCConverterUnit.operationMode",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCConverterOperatingModeKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCConverterOperatingModeKind."
+                },
+                "Substation": {
+                    "label": "cim:DCConverterUnit.Substation",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DCNodes": {
+                    "label": "cim:DCEquipmentContainer.DCNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCNode."
+                },
+                "Equipments": {
+                    "label": "cim:EquipmentContainer.Equipments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Equipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Equipment."
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:ConnectivityNodeContainer.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCLineSegment": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCLineSegment",
+            "fields": {
+                "PerLengthParameter": {
+                    "label": "cim:DCLineSegment.PerLengthParameter",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "resistance": {
+                    "label": "cim:DCLineSegment.resistance",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "length": {
+                    "label": "cim:DCLineSegment.length",
+                    "data_type": "Length",
+                    "data_type_prim": "Float"
+                },
+                "capacitance": {
+                    "label": "cim:DCLineSegment.capacitance",
+                    "data_type": "Capacitance",
+                    "data_type_prim": "Float"
+                },
+                "inductance": {
+                    "label": "cim:DCLineSegment.inductance",
+                    "data_type": "Inductance",
+                    "data_type_prim": "Float"
+                },
+                "DCTerminals": {
+                    "label": "cim:DCConductingEquipment.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCTerminal."
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "CsConverter": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:CsConverter",
+            "fields": {
+                "minGamma": {
+                    "label": "cim:CsConverter.minGamma",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "minAlpha": {
+                    "label": "cim:CsConverter.minAlpha",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "minIdc": {
+                    "label": "cim:CsConverter.minIdc",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "maxGamma": {
+                    "label": "cim:CsConverter.maxGamma",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "maxIdc": {
+                    "label": "cim:CsConverter.maxIdc",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "ratedIdc": {
+                    "label": "cim:CsConverter.ratedIdc",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "maxAlpha": {
+                    "label": "cim:CsConverter.maxAlpha",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "PccTerminal": {
+                    "label": "cim:ACDCConverter.PccTerminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "switchingLoss": {
+                    "label": "cim:ACDCConverter.switchingLoss",
+                    "data_type": "ActivePowerPerCurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "baseS": {
+                    "label": "cim:ACDCConverter.baseS",
+                    "data_type": "ApparentPower",
+                    "data_type_prim": "Float"
+                },
+                "minUdc": {
+                    "label": "cim:ACDCConverter.minUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "numberOfValves": {
+                    "label": "cim:ACDCConverter.numberOfValves",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "valveU0": {
+                    "label": "cim:ACDCConverter.valveU0",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "resistiveLoss": {
+                    "label": "cim:ACDCConverter.resistiveLoss",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "idleLoss": {
+                    "label": "cim:ACDCConverter.idleLoss",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedUdc": {
+                    "label": "cim:ACDCConverter.ratedUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "maxUdc": {
+                    "label": "cim:ACDCConverter.maxUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "DCTerminals": {
+                    "label": "cim:ACDCConverter.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ACDCConverterDCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ACDCConverterDCTerminal."
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "VsConverter": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:VsConverter",
+            "fields": {
+                "CapabilityCurve": {
+                    "label": "cim:VsConverter.CapabilityCurve",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "maxModulationIndex": {
+                    "label": "cim:VsConverter.maxModulationIndex",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "maxValveCurrent": {
+                    "label": "cim:VsConverter.maxValveCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "PccTerminal": {
+                    "label": "cim:ACDCConverter.PccTerminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "switchingLoss": {
+                    "label": "cim:ACDCConverter.switchingLoss",
+                    "data_type": "ActivePowerPerCurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "baseS": {
+                    "label": "cim:ACDCConverter.baseS",
+                    "data_type": "ApparentPower",
+                    "data_type_prim": "Float"
+                },
+                "minUdc": {
+                    "label": "cim:ACDCConverter.minUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "numberOfValves": {
+                    "label": "cim:ACDCConverter.numberOfValves",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "valveU0": {
+                    "label": "cim:ACDCConverter.valveU0",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "resistiveLoss": {
+                    "label": "cim:ACDCConverter.resistiveLoss",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "idleLoss": {
+                    "label": "cim:ACDCConverter.idleLoss",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedUdc": {
+                    "label": "cim:ACDCConverter.ratedUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "maxUdc": {
+                    "label": "cim:ACDCConverter.maxUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "DCTerminals": {
+                    "label": "cim:ACDCConverter.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ACDCConverterDCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ACDCConverterDCTerminal."
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCTerminal": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCTerminal",
+            "fields": {
+                "DCConductingEquipment": {
+                    "label": "cim:DCTerminal.DCConductingEquipment",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DCNode": {
+                    "label": "cim:DCBaseTerminal.DCNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "sequenceNumber": {
+                    "label": "cim:ACDCTerminal.sequenceNumber",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "Measurements": {
+                    "label": "cim:ACDCTerminal.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "BusNameMarker": {
+                    "label": "cim:ACDCTerminal.BusNameMarker",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:ACDCTerminal.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ACDCConverterDCTerminal": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ACDCConverterDCTerminal",
+            "fields": {
+                "polarity": {
+                    "label": "cim:ACDCConverterDCTerminal.polarity",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCPolarityKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCPolarityKind."
+                },
+                "DCConductingEquipment": {
+                    "label": "cim:ACDCConverterDCTerminal.DCConductingEquipment",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DCNode": {
+                    "label": "cim:DCBaseTerminal.DCNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "sequenceNumber": {
+                    "label": "cim:ACDCTerminal.sequenceNumber",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "Measurements": {
+                    "label": "cim:ACDCTerminal.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "BusNameMarker": {
+                    "label": "cim:ACDCTerminal.BusNameMarker",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:ACDCTerminal.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Breaker": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Breaker",
+            "fields": {
+                "ratedCurrent": {
+                    "label": "cim:Switch.ratedCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "retained": {
+                    "label": "cim:Switch.retained",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "SwitchSchedules": {
+                    "label": "cim:Switch.SwitchSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SwitchSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SwitchSchedule."
+                },
+                "normalOpen": {
+                    "label": "cim:Switch.normalOpen",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Disconnector": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Disconnector",
+            "fields": {
+                "ratedCurrent": {
+                    "label": "cim:Switch.ratedCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "retained": {
+                    "label": "cim:Switch.retained",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "SwitchSchedules": {
+                    "label": "cim:Switch.SwitchSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SwitchSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SwitchSchedule."
+                },
+                "normalOpen": {
+                    "label": "cim:Switch.normalOpen",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Switch": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Switch",
+            "fields": {
+                "ratedCurrent": {
+                    "label": "cim:Switch.ratedCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "retained": {
+                    "label": "cim:Switch.retained",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "SwitchSchedules": {
+                    "label": "cim:Switch.SwitchSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SwitchSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SwitchSchedule."
+                },
+                "normalOpen": {
+                    "label": "cim:Switch.normalOpen",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "LoadBreakSwitch": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:LoadBreakSwitch",
+            "fields": {
+                "ratedCurrent": {
+                    "label": "cim:Switch.ratedCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "retained": {
+                    "label": "cim:Switch.retained",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "SwitchSchedules": {
+                    "label": "cim:Switch.SwitchSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SwitchSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SwitchSchedule."
+                },
+                "normalOpen": {
+                    "label": "cim:Switch.normalOpen",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EnergyConsumer": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:EnergyConsumer",
+            "fields": {
+                "pfixed": {
+                    "label": "cim:EnergyConsumer.pfixed",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "qfixed": {
+                    "label": "cim:EnergyConsumer.qfixed",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "pfixedPct": {
+                    "label": "cim:EnergyConsumer.pfixedPct",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "qfixedPct": {
+                    "label": "cim:EnergyConsumer.qfixedPct",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "LoadResponse": {
+                    "label": "cim:EnergyConsumer.LoadResponse",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ConformLoad": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ConformLoad",
+            "fields": {
+                "LoadGroup": {
+                    "label": "cim:ConformLoad.LoadGroup",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "pfixed": {
+                    "label": "cim:EnergyConsumer.pfixed",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "qfixed": {
+                    "label": "cim:EnergyConsumer.qfixed",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "pfixedPct": {
+                    "label": "cim:EnergyConsumer.pfixedPct",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "qfixedPct": {
+                    "label": "cim:EnergyConsumer.qfixedPct",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "LoadResponse": {
+                    "label": "cim:EnergyConsumer.LoadResponse",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "NonConformLoad": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:NonConformLoad",
+            "fields": {
+                "LoadGroup": {
+                    "label": "cim:NonConformLoad.LoadGroup",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "pfixed": {
+                    "label": "cim:EnergyConsumer.pfixed",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "qfixed": {
+                    "label": "cim:EnergyConsumer.qfixed",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "pfixedPct": {
+                    "label": "cim:EnergyConsumer.pfixedPct",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "qfixedPct": {
+                    "label": "cim:EnergyConsumer.qfixedPct",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "LoadResponse": {
+                    "label": "cim:EnergyConsumer.LoadResponse",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "StationSupply": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:StationSupply",
+            "fields": {
+                "pfixed": {
+                    "label": "cim:EnergyConsumer.pfixed",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "qfixed": {
+                    "label": "cim:EnergyConsumer.qfixed",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "pfixedPct": {
+                    "label": "cim:EnergyConsumer.pfixedPct",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "qfixedPct": {
+                    "label": "cim:EnergyConsumer.qfixedPct",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "LoadResponse": {
+                    "label": "cim:EnergyConsumer.LoadResponse",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "GeneratingUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:GeneratingUnit",
+            "fields": {
+                "ControlAreaGeneratingUnit": {
+                    "label": "cim:GeneratingUnit.ControlAreaGeneratingUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaGeneratingUnit."
+                },
+                "genControlSource": {
+                    "label": "cim:GeneratingUnit.genControlSource",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GeneratorControlSource.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GeneratorControlSource."
+                },
+                "ratedNetMaxP": {
+                    "label": "cim:GeneratingUnit.ratedNetMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "totalEfficiency": {
+                    "label": "cim:GeneratingUnit.totalEfficiency",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "RotatingMachine": {
+                    "label": "cim:GeneratingUnit.RotatingMachine",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RotatingMachine.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RotatingMachine."
+                },
+                "governorSCD": {
+                    "label": "cim:GeneratingUnit.governorSCD",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "initialP": {
+                    "label": "cim:GeneratingUnit.initialP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minOperatingP": {
+                    "label": "cim:GeneratingUnit.minOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMinP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMinP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "variableCost": {
+                    "label": "cim:GeneratingUnit.variableCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "maximumAllowableSpinningReserve": {
+                    "label": "cim:GeneratingUnit.maximumAllowableSpinningReserve",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "startupCost": {
+                    "label": "cim:GeneratingUnit.startupCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "nominalP": {
+                    "label": "cim:GeneratingUnit.nominalP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "longPF": {
+                    "label": "cim:GeneratingUnit.longPF",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMaxP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "GrossToNetActivePowerCurves": {
+                    "label": "cim:GeneratingUnit.GrossToNetActivePowerCurves",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GrossToNetActivePowerCurve.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GrossToNetActivePowerCurve."
+                },
+                "shortPF": {
+                    "label": "cim:GeneratingUnit.shortPF",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "maxOperatingP": {
+                    "label": "cim:GeneratingUnit.maxOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "WindGeneratingUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:WindGeneratingUnit",
+            "fields": {
+                "windGenUnitType": {
+                    "label": "cim:WindGeneratingUnit.windGenUnitType",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#WindGenUnitKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#WindGenUnitKind."
+                },
+                "ControlAreaGeneratingUnit": {
+                    "label": "cim:GeneratingUnit.ControlAreaGeneratingUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaGeneratingUnit."
+                },
+                "genControlSource": {
+                    "label": "cim:GeneratingUnit.genControlSource",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GeneratorControlSource.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GeneratorControlSource."
+                },
+                "ratedNetMaxP": {
+                    "label": "cim:GeneratingUnit.ratedNetMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "totalEfficiency": {
+                    "label": "cim:GeneratingUnit.totalEfficiency",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "RotatingMachine": {
+                    "label": "cim:GeneratingUnit.RotatingMachine",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RotatingMachine.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RotatingMachine."
+                },
+                "governorSCD": {
+                    "label": "cim:GeneratingUnit.governorSCD",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "initialP": {
+                    "label": "cim:GeneratingUnit.initialP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minOperatingP": {
+                    "label": "cim:GeneratingUnit.minOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMinP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMinP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "variableCost": {
+                    "label": "cim:GeneratingUnit.variableCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "maximumAllowableSpinningReserve": {
+                    "label": "cim:GeneratingUnit.maximumAllowableSpinningReserve",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "startupCost": {
+                    "label": "cim:GeneratingUnit.startupCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "nominalP": {
+                    "label": "cim:GeneratingUnit.nominalP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "longPF": {
+                    "label": "cim:GeneratingUnit.longPF",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMaxP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "GrossToNetActivePowerCurves": {
+                    "label": "cim:GeneratingUnit.GrossToNetActivePowerCurves",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GrossToNetActivePowerCurve.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GrossToNetActivePowerCurve."
+                },
+                "shortPF": {
+                    "label": "cim:GeneratingUnit.shortPF",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "maxOperatingP": {
+                    "label": "cim:GeneratingUnit.maxOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "HydroGeneratingUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:HydroGeneratingUnit",
+            "fields": {
+                "HydroPowerPlant": {
+                    "label": "cim:HydroGeneratingUnit.HydroPowerPlant",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "energyConversionCapability": {
+                    "label": "cim:HydroGeneratingUnit.energyConversionCapability",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#HydroEnergyConversionKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#HydroEnergyConversionKind."
+                },
+                "ControlAreaGeneratingUnit": {
+                    "label": "cim:GeneratingUnit.ControlAreaGeneratingUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaGeneratingUnit."
+                },
+                "genControlSource": {
+                    "label": "cim:GeneratingUnit.genControlSource",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GeneratorControlSource.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GeneratorControlSource."
+                },
+                "ratedNetMaxP": {
+                    "label": "cim:GeneratingUnit.ratedNetMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "totalEfficiency": {
+                    "label": "cim:GeneratingUnit.totalEfficiency",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "RotatingMachine": {
+                    "label": "cim:GeneratingUnit.RotatingMachine",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RotatingMachine.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RotatingMachine."
+                },
+                "governorSCD": {
+                    "label": "cim:GeneratingUnit.governorSCD",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "initialP": {
+                    "label": "cim:GeneratingUnit.initialP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minOperatingP": {
+                    "label": "cim:GeneratingUnit.minOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMinP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMinP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "variableCost": {
+                    "label": "cim:GeneratingUnit.variableCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "maximumAllowableSpinningReserve": {
+                    "label": "cim:GeneratingUnit.maximumAllowableSpinningReserve",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "startupCost": {
+                    "label": "cim:GeneratingUnit.startupCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "nominalP": {
+                    "label": "cim:GeneratingUnit.nominalP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "longPF": {
+                    "label": "cim:GeneratingUnit.longPF",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMaxP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "GrossToNetActivePowerCurves": {
+                    "label": "cim:GeneratingUnit.GrossToNetActivePowerCurves",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GrossToNetActivePowerCurve.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GrossToNetActivePowerCurve."
+                },
+                "shortPF": {
+                    "label": "cim:GeneratingUnit.shortPF",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "maxOperatingP": {
+                    "label": "cim:GeneratingUnit.maxOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SolarGeneratingUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SolarGeneratingUnit",
+            "fields": {
+                "ControlAreaGeneratingUnit": {
+                    "label": "cim:GeneratingUnit.ControlAreaGeneratingUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaGeneratingUnit."
+                },
+                "genControlSource": {
+                    "label": "cim:GeneratingUnit.genControlSource",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GeneratorControlSource.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GeneratorControlSource."
+                },
+                "ratedNetMaxP": {
+                    "label": "cim:GeneratingUnit.ratedNetMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "totalEfficiency": {
+                    "label": "cim:GeneratingUnit.totalEfficiency",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "RotatingMachine": {
+                    "label": "cim:GeneratingUnit.RotatingMachine",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RotatingMachine.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RotatingMachine."
+                },
+                "governorSCD": {
+                    "label": "cim:GeneratingUnit.governorSCD",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "initialP": {
+                    "label": "cim:GeneratingUnit.initialP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minOperatingP": {
+                    "label": "cim:GeneratingUnit.minOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMinP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMinP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "variableCost": {
+                    "label": "cim:GeneratingUnit.variableCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "maximumAllowableSpinningReserve": {
+                    "label": "cim:GeneratingUnit.maximumAllowableSpinningReserve",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "startupCost": {
+                    "label": "cim:GeneratingUnit.startupCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "nominalP": {
+                    "label": "cim:GeneratingUnit.nominalP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "longPF": {
+                    "label": "cim:GeneratingUnit.longPF",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMaxP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "GrossToNetActivePowerCurves": {
+                    "label": "cim:GeneratingUnit.GrossToNetActivePowerCurves",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GrossToNetActivePowerCurve.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GrossToNetActivePowerCurve."
+                },
+                "shortPF": {
+                    "label": "cim:GeneratingUnit.shortPF",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "maxOperatingP": {
+                    "label": "cim:GeneratingUnit.maxOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ThermalGeneratingUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ThermalGeneratingUnit",
+            "fields": {
+                "FossilFuels": {
+                    "label": "cim:ThermalGeneratingUnit.FossilFuels",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#FossilFuel.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#FossilFuel."
+                },
+                "ControlAreaGeneratingUnit": {
+                    "label": "cim:GeneratingUnit.ControlAreaGeneratingUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaGeneratingUnit."
+                },
+                "genControlSource": {
+                    "label": "cim:GeneratingUnit.genControlSource",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GeneratorControlSource.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GeneratorControlSource."
+                },
+                "ratedNetMaxP": {
+                    "label": "cim:GeneratingUnit.ratedNetMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "totalEfficiency": {
+                    "label": "cim:GeneratingUnit.totalEfficiency",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "RotatingMachine": {
+                    "label": "cim:GeneratingUnit.RotatingMachine",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RotatingMachine.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RotatingMachine."
+                },
+                "governorSCD": {
+                    "label": "cim:GeneratingUnit.governorSCD",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "initialP": {
+                    "label": "cim:GeneratingUnit.initialP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minOperatingP": {
+                    "label": "cim:GeneratingUnit.minOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMinP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMinP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "variableCost": {
+                    "label": "cim:GeneratingUnit.variableCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "maximumAllowableSpinningReserve": {
+                    "label": "cim:GeneratingUnit.maximumAllowableSpinningReserve",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "startupCost": {
+                    "label": "cim:GeneratingUnit.startupCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "nominalP": {
+                    "label": "cim:GeneratingUnit.nominalP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "longPF": {
+                    "label": "cim:GeneratingUnit.longPF",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMaxP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "GrossToNetActivePowerCurves": {
+                    "label": "cim:GeneratingUnit.GrossToNetActivePowerCurves",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GrossToNetActivePowerCurve.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GrossToNetActivePowerCurve."
+                },
+                "shortPF": {
+                    "label": "cim:GeneratingUnit.shortPF",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "maxOperatingP": {
+                    "label": "cim:GeneratingUnit.maxOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "NuclearGeneratingUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:NuclearGeneratingUnit",
+            "fields": {
+                "ControlAreaGeneratingUnit": {
+                    "label": "cim:GeneratingUnit.ControlAreaGeneratingUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaGeneratingUnit."
+                },
+                "genControlSource": {
+                    "label": "cim:GeneratingUnit.genControlSource",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GeneratorControlSource.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GeneratorControlSource."
+                },
+                "ratedNetMaxP": {
+                    "label": "cim:GeneratingUnit.ratedNetMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "totalEfficiency": {
+                    "label": "cim:GeneratingUnit.totalEfficiency",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "RotatingMachine": {
+                    "label": "cim:GeneratingUnit.RotatingMachine",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RotatingMachine.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RotatingMachine."
+                },
+                "governorSCD": {
+                    "label": "cim:GeneratingUnit.governorSCD",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "initialP": {
+                    "label": "cim:GeneratingUnit.initialP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "minOperatingP": {
+                    "label": "cim:GeneratingUnit.minOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMinP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMinP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "variableCost": {
+                    "label": "cim:GeneratingUnit.variableCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "maximumAllowableSpinningReserve": {
+                    "label": "cim:GeneratingUnit.maximumAllowableSpinningReserve",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "startupCost": {
+                    "label": "cim:GeneratingUnit.startupCost",
+                    "data_type": "Money",
+                    "data_type_prim": "Decimal"
+                },
+                "nominalP": {
+                    "label": "cim:GeneratingUnit.nominalP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "longPF": {
+                    "label": "cim:GeneratingUnit.longPF",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "ratedGrossMaxP": {
+                    "label": "cim:GeneratingUnit.ratedGrossMaxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "GrossToNetActivePowerCurves": {
+                    "label": "cim:GeneratingUnit.GrossToNetActivePowerCurves",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GrossToNetActivePowerCurve.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#GrossToNetActivePowerCurve."
+                },
+                "shortPF": {
+                    "label": "cim:GeneratingUnit.shortPF",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "maxOperatingP": {
+                    "label": "cim:GeneratingUnit.maxOperatingP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "RegulatingControl": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:RegulatingControl",
+            "fields": {
+                "RegulatingCondEq": {
+                    "label": "cim:RegulatingControl.RegulatingCondEq",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingCondEq.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingCondEq."
+                },
+                "RegulationSchedule": {
+                    "label": "cim:RegulatingControl.RegulationSchedule",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegulationSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegulationSchedule."
+                },
+                "mode": {
+                    "label": "cim:RegulatingControl.mode",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind."
+                },
+                "Terminal": {
+                    "label": "cim:RegulatingControl.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SynchronousMachine": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SynchronousMachine",
+            "fields": {
+                "shortCircuitRotorType": {
+                    "label": "cim:SynchronousMachine.shortCircuitRotorType",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ShortCircuitRotorKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ShortCircuitRotorKind."
+                },
+                "voltageRegulationRange": {
+                    "label": "cim:SynchronousMachine.voltageRegulationRange",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "r0": {
+                    "label": "cim:SynchronousMachine.r0",
+                    "data_type": "PU",
+                    "data_type_prim": "Float"
+                },
+                "ikk": {
+                    "label": "cim:SynchronousMachine.ikk",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "earthingStarPointR": {
+                    "label": "cim:SynchronousMachine.earthingStarPointR",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "satDirectSubtransX": {
+                    "label": "cim:SynchronousMachine.satDirectSubtransX",
+                    "data_type": "PU",
+                    "data_type_prim": "Float"
+                },
+                "minQ": {
+                    "label": "cim:SynchronousMachine.minQ",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "r2": {
+                    "label": "cim:SynchronousMachine.r2",
+                    "data_type": "PU",
+                    "data_type_prim": "Float"
+                },
+                "mu": {
+                    "label": "cim:SynchronousMachine.mu",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "qPercent": {
+                    "label": "cim:SynchronousMachine.qPercent",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "earthing": {
+                    "label": "cim:SynchronousMachine.earthing",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "maxQ": {
+                    "label": "cim:SynchronousMachine.maxQ",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "satDirectSyncX": {
+                    "label": "cim:SynchronousMachine.satDirectSyncX",
+                    "data_type": "PU",
+                    "data_type_prim": "Float"
+                },
+                "r": {
+                    "label": "cim:SynchronousMachine.r",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "x0": {
+                    "label": "cim:SynchronousMachine.x0",
+                    "data_type": "PU",
+                    "data_type_prim": "Float"
+                },
+                "InitialReactiveCapabilityCurve": {
+                    "label": "cim:SynchronousMachine.InitialReactiveCapabilityCurve",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "type": {
+                    "label": "cim:SynchronousMachine.type",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineKind."
+                },
+                "earthingStarPointX": {
+                    "label": "cim:SynchronousMachine.earthingStarPointX",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "x2": {
+                    "label": "cim:SynchronousMachine.x2",
+                    "data_type": "PU",
+                    "data_type_prim": "Float"
+                },
+                "satDirectTransX": {
+                    "label": "cim:SynchronousMachine.satDirectTransX",
+                    "data_type": "PU",
+                    "data_type_prim": "Float"
+                },
+                "GeneratingUnit": {
+                    "label": "cim:RotatingMachine.GeneratingUnit",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ratedS": {
+                    "label": "cim:RotatingMachine.ratedS",
+                    "data_type": "ApparentPower",
+                    "data_type_prim": "Float"
+                },
+                "ratedPowerFactor": {
+                    "label": "cim:RotatingMachine.ratedPowerFactor",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "ratedU": {
+                    "label": "cim:RotatingMachine.ratedU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "HydroPump": {
+                    "label": "cim:RotatingMachine.HydroPump",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#HydroPump.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#HydroPump."
+                },
+                "RegulatingControl": {
+                    "label": "cim:RegulatingCondEq.RegulatingControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "AsynchronousMachine": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:AsynchronousMachine",
+            "fields": {
+                "reversible": {
+                    "label": "cim:AsynchronousMachine.reversible",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "nominalSpeed": {
+                    "label": "cim:AsynchronousMachine.nominalSpeed",
+                    "data_type": "RotationSpeed",
+                    "data_type_prim": "Float"
+                },
+                "efficiency": {
+                    "label": "cim:AsynchronousMachine.efficiency",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "iaIrRatio": {
+                    "label": "cim:AsynchronousMachine.iaIrRatio",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "polePairNumber": {
+                    "label": "cim:AsynchronousMachine.polePairNumber",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "rxLockedRotorRatio": {
+                    "label": "cim:AsynchronousMachine.rxLockedRotorRatio",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "nominalFrequency": {
+                    "label": "cim:AsynchronousMachine.nominalFrequency",
+                    "data_type": "Frequency",
+                    "data_type_prim": "Float"
+                },
+                "ratedMechanicalPower": {
+                    "label": "cim:AsynchronousMachine.ratedMechanicalPower",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "converterFedDrive": {
+                    "label": "cim:AsynchronousMachine.converterFedDrive",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "GeneratingUnit": {
+                    "label": "cim:RotatingMachine.GeneratingUnit",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ratedS": {
+                    "label": "cim:RotatingMachine.ratedS",
+                    "data_type": "ApparentPower",
+                    "data_type_prim": "Float"
+                },
+                "ratedPowerFactor": {
+                    "label": "cim:RotatingMachine.ratedPowerFactor",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "ratedU": {
+                    "label": "cim:RotatingMachine.ratedU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "HydroPump": {
+                    "label": "cim:RotatingMachine.HydroPump",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#HydroPump.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#HydroPump."
+                },
+                "RegulatingControl": {
+                    "label": "cim:RegulatingCondEq.RegulatingControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EnergySource": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:EnergySource",
+            "fields": {
+                "xn": {
+                    "label": "cim:EnergySource.xn",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "r": {
+                    "label": "cim:EnergySource.r",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "voltageAngle": {
+                    "label": "cim:EnergySource.voltageAngle",
+                    "data_type": "AngleRadians",
+                    "data_type_prim": "Float"
+                },
+                "voltageMagnitude": {
+                    "label": "cim:EnergySource.voltageMagnitude",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "r0": {
+                    "label": "cim:EnergySource.r0",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "x": {
+                    "label": "cim:EnergySource.x",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "nominalVoltage": {
+                    "label": "cim:EnergySource.nominalVoltage",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "rn": {
+                    "label": "cim:EnergySource.rn",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "x0": {
+                    "label": "cim:EnergySource.x0",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "EnergySchedulingType": {
+                    "label": "cim:EnergySource.EnergySchedulingType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EnergySchedulingType": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "entsoe:EnergySchedulingType",
+            "fields": {
+                "EnergySource": {
+                    "label": "cim:EnergySchedulingType.EnergySource",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#EnergySource.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#EnergySource."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "StaticVarCompensator": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:StaticVarCompensator",
+            "fields": {
+                "capacitiveRating": {
+                    "label": "cim:StaticVarCompensator.capacitiveRating",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "slope": {
+                    "label": "cim:StaticVarCompensator.slope",
+                    "data_type": "VoltagePerReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "voltageSetPoint": {
+                    "label": "cim:StaticVarCompensator.voltageSetPoint",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "sVCControlMode": {
+                    "label": "cim:StaticVarCompensator.sVCControlMode",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SVCControlMode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SVCControlMode."
+                },
+                "inductiveRating": {
+                    "label": "cim:StaticVarCompensator.inductiveRating",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "RegulatingControl": {
+                    "label": "cim:RegulatingCondEq.RegulatingControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PowerTransformer": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PowerTransformer",
+            "fields": {
+                "isPartOfGeneratorUnit": {
+                    "label": "cim:PowerTransformer.isPartOfGeneratorUnit",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "PowerTransformerEnd": {
+                    "label": "cim:PowerTransformer.PowerTransformerEnd",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PowerTransformerEnd.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PowerTransformerEnd."
+                },
+                "beforeShortCircuitAnglePf": {
+                    "label": "cim:PowerTransformer.beforeShortCircuitAnglePf",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "beforeShCircuitHighestOperatingCurrent": {
+                    "label": "cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "operationalValuesConsidered": {
+                    "label": "cim:PowerTransformer.operationalValuesConsidered",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "beforeShCircuitHighestOperatingVoltage": {
+                    "label": "cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "highSideMinOperatingU": {
+                    "label": "cim:PowerTransformer.highSideMinOperatingU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PowerTransformerEnd": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PowerTransformerEnd",
+            "fields": {
+                "ratedS": {
+                    "label": "cim:PowerTransformerEnd.ratedS",
+                    "data_type": "ApparentPower",
+                    "data_type_prim": "Float"
+                },
+                "PowerTransformer": {
+                    "label": "cim:PowerTransformerEnd.PowerTransformer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "x": {
+                    "label": "cim:PowerTransformerEnd.x",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "b0": {
+                    "label": "cim:PowerTransformerEnd.b0",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "x0": {
+                    "label": "cim:PowerTransformerEnd.x0",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "r": {
+                    "label": "cim:PowerTransformerEnd.r",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "g0": {
+                    "label": "cim:PowerTransformerEnd.g0",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                },
+                "connectionKind": {
+                    "label": "cim:PowerTransformerEnd.connectionKind",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection."
+                },
+                "phaseAngleClock": {
+                    "label": "cim:PowerTransformerEnd.phaseAngleClock",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "b": {
+                    "label": "cim:PowerTransformerEnd.b",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "g": {
+                    "label": "cim:PowerTransformerEnd.g",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                },
+                "ratedU": {
+                    "label": "cim:PowerTransformerEnd.ratedU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "r0": {
+                    "label": "cim:PowerTransformerEnd.r0",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "xground": {
+                    "label": "cim:TransformerEnd.xground",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "Terminal": {
+                    "label": "cim:TransformerEnd.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "BaseVoltage": {
+                    "label": "cim:TransformerEnd.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "grounded": {
+                    "label": "cim:TransformerEnd.grounded",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "rground": {
+                    "label": "cim:TransformerEnd.rground",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "endNumber": {
+                    "label": "cim:TransformerEnd.endNumber",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "PhaseTapChanger": {
+                    "label": "cim:TransformerEnd.PhaseTapChanger",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseTapChanger.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseTapChanger."
+                },
+                "RatioTapChanger": {
+                    "label": "cim:TransformerEnd.RatioTapChanger",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RatioTapChanger.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RatioTapChanger."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "TapChangerControl": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:TapChangerControl",
+            "fields": {
+                "TapChanger": {
+                    "label": "cim:TapChangerControl.TapChanger",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TapChanger.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TapChanger."
+                },
+                "RegulatingCondEq": {
+                    "label": "cim:RegulatingControl.RegulatingCondEq",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingCondEq.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingCondEq."
+                },
+                "RegulationSchedule": {
+                    "label": "cim:RegulatingControl.RegulationSchedule",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegulationSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegulationSchedule."
+                },
+                "mode": {
+                    "label": "cim:RegulatingControl.mode",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind."
+                },
+                "Terminal": {
+                    "label": "cim:RegulatingControl.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "RatioTapChanger": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:RatioTapChanger",
+            "fields": {
+                "tculControlMode": {
+                    "label": "cim:RatioTapChanger.tculControlMode",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TransformerControlMode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TransformerControlMode."
+                },
+                "stepVoltageIncrement": {
+                    "label": "cim:RatioTapChanger.stepVoltageIncrement",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "TransformerEnd": {
+                    "label": "cim:RatioTapChanger.TransformerEnd",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "RatioTapChangerTable": {
+                    "label": "cim:RatioTapChanger.RatioTapChangerTable",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ltcFlag": {
+                    "label": "cim:TapChanger.ltcFlag",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normalStep": {
+                    "label": "cim:TapChanger.normalStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "TapSchedules": {
+                    "label": "cim:TapChanger.TapSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TapSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TapSchedule."
+                },
+                "TapChangerControl": {
+                    "label": "cim:TapChanger.TapChangerControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "lowStep": {
+                    "label": "cim:TapChanger.lowStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "highStep": {
+                    "label": "cim:TapChanger.highStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "neutralStep": {
+                    "label": "cim:TapChanger.neutralStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "neutralU": {
+                    "label": "cim:TapChanger.neutralU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerLinear": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PhaseTapChangerLinear",
+            "fields": {
+                "stepPhaseShiftIncrement": {
+                    "label": "cim:PhaseTapChangerLinear.stepPhaseShiftIncrement",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "xMin": {
+                    "label": "cim:PhaseTapChangerLinear.xMin",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "xMax": {
+                    "label": "cim:PhaseTapChangerLinear.xMax",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "TransformerEnd": {
+                    "label": "cim:PhaseTapChanger.TransformerEnd",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ltcFlag": {
+                    "label": "cim:TapChanger.ltcFlag",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normalStep": {
+                    "label": "cim:TapChanger.normalStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "TapSchedules": {
+                    "label": "cim:TapChanger.TapSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TapSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TapSchedule."
+                },
+                "TapChangerControl": {
+                    "label": "cim:TapChanger.TapChangerControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "lowStep": {
+                    "label": "cim:TapChanger.lowStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "highStep": {
+                    "label": "cim:TapChanger.highStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "neutralStep": {
+                    "label": "cim:TapChanger.neutralStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "neutralU": {
+                    "label": "cim:TapChanger.neutralU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerAsymmetrical": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PhaseTapChangerAsymmetrical",
+            "fields": {
+                "windingConnectionAngle": {
+                    "label": "cim:PhaseTapChangerAsymmetrical.windingConnectionAngle",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "xMin": {
+                    "label": "cim:PhaseTapChangerNonLinear.xMin",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "xMax": {
+                    "label": "cim:PhaseTapChangerNonLinear.xMax",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "voltageStepIncrement": {
+                    "label": "cim:PhaseTapChangerNonLinear.voltageStepIncrement",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "TransformerEnd": {
+                    "label": "cim:PhaseTapChanger.TransformerEnd",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ltcFlag": {
+                    "label": "cim:TapChanger.ltcFlag",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normalStep": {
+                    "label": "cim:TapChanger.normalStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "TapSchedules": {
+                    "label": "cim:TapChanger.TapSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TapSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TapSchedule."
+                },
+                "TapChangerControl": {
+                    "label": "cim:TapChanger.TapChangerControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "lowStep": {
+                    "label": "cim:TapChanger.lowStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "highStep": {
+                    "label": "cim:TapChanger.highStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "neutralStep": {
+                    "label": "cim:TapChanger.neutralStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "neutralU": {
+                    "label": "cim:TapChanger.neutralU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerSymmetrical": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PhaseTapChangerSymmetrical",
+            "fields": {
+                "xMin": {
+                    "label": "cim:PhaseTapChangerNonLinear.xMin",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "xMax": {
+                    "label": "cim:PhaseTapChangerNonLinear.xMax",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "voltageStepIncrement": {
+                    "label": "cim:PhaseTapChangerNonLinear.voltageStepIncrement",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "TransformerEnd": {
+                    "label": "cim:PhaseTapChanger.TransformerEnd",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ltcFlag": {
+                    "label": "cim:TapChanger.ltcFlag",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normalStep": {
+                    "label": "cim:TapChanger.normalStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "TapSchedules": {
+                    "label": "cim:TapChanger.TapSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TapSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TapSchedule."
+                },
+                "TapChangerControl": {
+                    "label": "cim:TapChanger.TapChangerControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "lowStep": {
+                    "label": "cim:TapChanger.lowStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "highStep": {
+                    "label": "cim:TapChanger.highStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "neutralStep": {
+                    "label": "cim:TapChanger.neutralStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "neutralU": {
+                    "label": "cim:TapChanger.neutralU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerTabular": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PhaseTapChangerTabular",
+            "fields": {
+                "PhaseTapChangerTable": {
+                    "label": "cim:PhaseTapChangerTabular.PhaseTapChangerTable",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "TransformerEnd": {
+                    "label": "cim:PhaseTapChanger.TransformerEnd",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ltcFlag": {
+                    "label": "cim:TapChanger.ltcFlag",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "normalStep": {
+                    "label": "cim:TapChanger.normalStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "TapSchedules": {
+                    "label": "cim:TapChanger.TapSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TapSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#TapSchedule."
+                },
+                "TapChangerControl": {
+                    "label": "cim:TapChanger.TapChangerControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "lowStep": {
+                    "label": "cim:TapChanger.lowStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "highStep": {
+                    "label": "cim:TapChanger.highStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "neutralStep": {
+                    "label": "cim:TapChanger.neutralStep",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "neutralU": {
+                    "label": "cim:TapChanger.neutralU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerTablePoint": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PhaseTapChangerTablePoint",
+            "fields": {
+                "angle": {
+                    "label": "cim:PhaseTapChangerTablePoint.angle",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "PhaseTapChangerTable": {
+                    "label": "cim:PhaseTapChangerTablePoint.PhaseTapChangerTable",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "g": {
+                    "label": "cim:TapChangerTablePoint.g",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "r": {
+                    "label": "cim:TapChangerTablePoint.r",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "x": {
+                    "label": "cim:TapChangerTablePoint.x",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "b": {
+                    "label": "cim:TapChangerTablePoint.b",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "ratio": {
+                    "label": "cim:TapChangerTablePoint.ratio",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "step": {
+                    "label": "cim:TapChangerTablePoint.step",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                }
+            }
+        },
+        "RatioTapChangerTable": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:RatioTapChangerTable",
+            "fields": {
+                "RatioTapChangerTablePoint": {
+                    "label": "cim:RatioTapChangerTable.RatioTapChangerTablePoint",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RatioTapChangerTablePoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RatioTapChangerTablePoint."
+                },
+                "RatioTapChanger": {
+                    "label": "cim:RatioTapChangerTable.RatioTapChanger",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RatioTapChanger.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RatioTapChanger."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "RatioTapChangerTablePoint": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:RatioTapChangerTablePoint",
+            "fields": {
+                "RatioTapChangerTable": {
+                    "label": "cim:RatioTapChangerTablePoint.RatioTapChangerTable",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "g": {
+                    "label": "cim:TapChangerTablePoint.g",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "r": {
+                    "label": "cim:TapChangerTablePoint.r",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "x": {
+                    "label": "cim:TapChangerTablePoint.x",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "b": {
+                    "label": "cim:TapChangerTablePoint.b",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "ratio": {
+                    "label": "cim:TapChangerTablePoint.ratio",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "step": {
+                    "label": "cim:TapChangerTablePoint.step",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                }
+            }
+        },
+        "LinearShuntCompensator": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:LinearShuntCompensator",
+            "fields": {
+                "gPerSection": {
+                    "label": "cim:LinearShuntCompensator.gPerSection",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                },
+                "b0PerSection": {
+                    "label": "cim:LinearShuntCompensator.b0PerSection",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "g0PerSection": {
+                    "label": "cim:LinearShuntCompensator.g0PerSection",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                },
+                "bPerSection": {
+                    "label": "cim:LinearShuntCompensator.bPerSection",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "normalSections": {
+                    "label": "cim:ShuntCompensator.normalSections",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "nomU": {
+                    "label": "cim:ShuntCompensator.nomU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "grounded": {
+                    "label": "cim:ShuntCompensator.grounded",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "switchOnCount": {
+                    "label": "cim:ShuntCompensator.switchOnCount",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "maximumSections": {
+                    "label": "cim:ShuntCompensator.maximumSections",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "switchOnDate": {
+                    "label": "cim:ShuntCompensator.switchOnDate",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "voltageSensitivity": {
+                    "label": "cim:ShuntCompensator.voltageSensitivity",
+                    "data_type": "VoltagePerReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "aVRDelay": {
+                    "label": "cim:ShuntCompensator.aVRDelay",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "RegulatingControl": {
+                    "label": "cim:RegulatingCondEq.RegulatingControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "NonlinearShuntCompensator": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:NonlinearShuntCompensator",
+            "fields": {
+                "NonlinearShuntCompensatorPoints": {
+                    "label": "cim:NonlinearShuntCompensator.NonlinearShuntCompensatorPoints",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#NonlinearShuntCompensatorPoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#NonlinearShuntCompensatorPoint."
+                },
+                "normalSections": {
+                    "label": "cim:ShuntCompensator.normalSections",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "nomU": {
+                    "label": "cim:ShuntCompensator.nomU",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "grounded": {
+                    "label": "cim:ShuntCompensator.grounded",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "switchOnCount": {
+                    "label": "cim:ShuntCompensator.switchOnCount",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "maximumSections": {
+                    "label": "cim:ShuntCompensator.maximumSections",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "switchOnDate": {
+                    "label": "cim:ShuntCompensator.switchOnDate",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "voltageSensitivity": {
+                    "label": "cim:ShuntCompensator.voltageSensitivity",
+                    "data_type": "VoltagePerReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "aVRDelay": {
+                    "label": "cim:ShuntCompensator.aVRDelay",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "RegulatingControl": {
+                    "label": "cim:RegulatingCondEq.RegulatingControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "NonlinearShuntCompensatorPoint": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:NonlinearShuntCompensatorPoint",
+            "fields": {
+                "NonlinearShuntCompensator": {
+                    "label": "cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "b": {
+                    "label": "cim:NonlinearShuntCompensatorPoint.b",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "sectionNumber": {
+                    "label": "cim:NonlinearShuntCompensatorPoint.sectionNumber",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "b0": {
+                    "label": "cim:NonlinearShuntCompensatorPoint.b0",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "g0": {
+                    "label": "cim:NonlinearShuntCompensatorPoint.g0",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                },
+                "g": {
+                    "label": "cim:NonlinearShuntCompensatorPoint.g",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                }
+            }
+        },
+        "EquivalentBranch": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:EquivalentBranch",
+            "fields": {
+                "x21": {
+                    "label": "cim:EquivalentBranch.x21",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "zeroX12": {
+                    "label": "cim:EquivalentBranch.zeroX12",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "r21": {
+                    "label": "cim:EquivalentBranch.r21",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "zeroX21": {
+                    "label": "cim:EquivalentBranch.zeroX21",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "zeroR12": {
+                    "label": "cim:EquivalentBranch.zeroR12",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "zeroR21": {
+                    "label": "cim:EquivalentBranch.zeroR21",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "r": {
+                    "label": "cim:EquivalentBranch.r",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "positiveX21": {
+                    "label": "cim:EquivalentBranch.positiveX21",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "x": {
+                    "label": "cim:EquivalentBranch.x",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "negativeR12": {
+                    "label": "cim:EquivalentBranch.negativeR12",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "negativeR21": {
+                    "label": "cim:EquivalentBranch.negativeR21",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "negativeX21": {
+                    "label": "cim:EquivalentBranch.negativeX21",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "positiveX12": {
+                    "label": "cim:EquivalentBranch.positiveX12",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "positiveR12": {
+                    "label": "cim:EquivalentBranch.positiveR12",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "positiveR21": {
+                    "label": "cim:EquivalentBranch.positiveR21",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "negativeX12": {
+                    "label": "cim:EquivalentBranch.negativeX12",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "EquivalentNetwork": {
+                    "label": "cim:EquivalentEquipment.EquivalentNetwork",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EquivalentInjection": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:EquivalentInjection",
+            "fields": {
+                "x": {
+                    "label": "cim:EquivalentInjection.x",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "ReactiveCapabilityCurve": {
+                    "label": "cim:EquivalentInjection.ReactiveCapabilityCurve",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "maxQ": {
+                    "label": "cim:EquivalentInjection.maxQ",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "regulationCapability": {
+                    "label": "cim:EquivalentInjection.regulationCapability",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "r0": {
+                    "label": "cim:EquivalentInjection.r0",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "minQ": {
+                    "label": "cim:EquivalentInjection.minQ",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "r": {
+                    "label": "cim:EquivalentInjection.r",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "minP": {
+                    "label": "cim:EquivalentInjection.minP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "x2": {
+                    "label": "cim:EquivalentInjection.x2",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "x0": {
+                    "label": "cim:EquivalentInjection.x0",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "maxP": {
+                    "label": "cim:EquivalentInjection.maxP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "r2": {
+                    "label": "cim:EquivalentInjection.r2",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "EquivalentNetwork": {
+                    "label": "cim:EquivalentEquipment.EquivalentNetwork",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SeriesCompensator": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SeriesCompensator",
+            "fields": {
+                "x": {
+                    "label": "cim:SeriesCompensator.x",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "r": {
+                    "label": "cim:SeriesCompensator.r",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "varistorPresent": {
+                    "label": "cim:SeriesCompensator.varistorPresent",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "varistorVoltageThreshold": {
+                    "label": "cim:SeriesCompensator.varistorVoltageThreshold",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "r0": {
+                    "label": "cim:SeriesCompensator.r0",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "x0": {
+                    "label": "cim:SeriesCompensator.x0",
+                    "data_type": "Reactance",
+                    "data_type_prim": "Float"
+                },
+                "varistorRatedCurrent": {
+                    "label": "cim:SeriesCompensator.varistorRatedCurrent",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Analog": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Analog",
+            "fields": {
+                "AnalogValues": {
+                    "label": "cim:Analog.AnalogValues",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#AnalogValue.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#AnalogValue."
+                },
+                "positiveFlowIn": {
+                    "label": "cim:Analog.positiveFlowIn",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "LimitSets": {
+                    "label": "cim:Analog.LimitSets",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#AnalogLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#AnalogLimitSet."
+                },
+                "phases": {
+                    "label": "cim:Measurement.phases",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode."
+                },
+                "PowerSystemResource": {
+                    "label": "cim:Measurement.PowerSystemResource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "unitSymbol": {
+                    "label": "cim:Measurement.unitSymbol",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "measurementType": {
+                    "label": "cim:Measurement.measurementType",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "Terminal": {
+                    "label": "cim:Measurement.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "unitMultiplier": {
+                    "label": "cim:Measurement.unitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "AnalogValue": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:AnalogValue",
+            "fields": {
+                "AnalogControl": {
+                    "label": "cim:AnalogValue.AnalogControl",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#AnalogControl.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#AnalogControl."
+                },
+                "value": {
+                    "label": "cim:AnalogValue.value",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "Analog": {
+                    "label": "cim:AnalogValue.Analog",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "MeasurementValueQuality": {
+                    "label": "cim:MeasurementValue.MeasurementValueQuality",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#MeasurementValueQuality.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#MeasurementValueQuality."
+                },
+                "sensorAccuracy": {
+                    "label": "cim:MeasurementValue.sensorAccuracy",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "timeStamp": {
+                    "label": "cim:MeasurementValue.timeStamp",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "MeasurementValueSource": {
+                    "label": "cim:MeasurementValue.MeasurementValueSource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "MeasurementValueSource": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:MeasurementValueSource",
+            "fields": {
+                "MeasurementValues": {
+                    "label": "cim:MeasurementValueSource.MeasurementValues",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#MeasurementValue.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#MeasurementValue."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ReactiveCapabilityCurve": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ReactiveCapabilityCurve",
+            "fields": {
+                "EquivalentInjection": {
+                    "label": "cim:ReactiveCapabilityCurve.EquivalentInjection",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#EquivalentInjection.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#EquivalentInjection."
+                },
+                "InitiallyUsedBySynchronousMachines": {
+                    "label": "cim:ReactiveCapabilityCurve.InitiallyUsedBySynchronousMachines",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachine.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachine."
+                },
+                "curveStyle": {
+                    "label": "cim:Curve.curveStyle",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#CurveStyle.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#CurveStyle."
+                },
+                "CurveDatas": {
+                    "label": "cim:Curve.CurveDatas",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#CurveData.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#CurveData."
+                },
+                "y2Unit": {
+                    "label": "cim:Curve.y2Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "y1Unit": {
+                    "label": "cim:Curve.y1Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "xUnit": {
+                    "label": "cim:Curve.xUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "CurveData": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:CurveData",
+            "fields": {
+                "y1value": {
+                    "label": "cim:CurveData.y1value",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "xvalue": {
+                    "label": "cim:CurveData.xvalue",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "Curve": {
+                    "label": "cim:CurveData.Curve",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "y2value": {
+                    "label": "cim:CurveData.y2value",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                }
+            }
+        },
+        "FullModel": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:FullModel",
+            "fields": {}
+        },
+        "Accumulator": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Accumulator",
+            "fields": {
+                "LimitSets": {
+                    "label": "cim:Accumulator.LimitSets",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#AccumulatorLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#AccumulatorLimitSet."
+                },
+                "AccumulatorValues": {
+                    "label": "cim:Accumulator.AccumulatorValues",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#AccumulatorValue.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#AccumulatorValue."
+                },
+                "phases": {
+                    "label": "cim:Measurement.phases",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode."
+                },
+                "PowerSystemResource": {
+                    "label": "cim:Measurement.PowerSystemResource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "unitSymbol": {
+                    "label": "cim:Measurement.unitSymbol",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "measurementType": {
+                    "label": "cim:Measurement.measurementType",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "Terminal": {
+                    "label": "cim:Measurement.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "unitMultiplier": {
+                    "label": "cim:Measurement.unitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "AccumulatorLimit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:AccumulatorLimit",
+            "fields": {
+                "value": {
+                    "label": "cim:AccumulatorLimit.value",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "LimitSet": {
+                    "label": "cim:AccumulatorLimit.LimitSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "AccumulatorLimitSet": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:AccumulatorLimitSet",
+            "fields": {
+                "Limits": {
+                    "label": "cim:AccumulatorLimitSet.Limits",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#AccumulatorLimit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#AccumulatorLimit."
+                },
+                "Measurements": {
+                    "label": "cim:AccumulatorLimitSet.Measurements",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "isPercentageLimits": {
+                    "label": "cim:LimitSet.isPercentageLimits",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "AccumulatorReset": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:AccumulatorReset",
+            "fields": {
+                "AccumulatorValue": {
+                    "label": "cim:AccumulatorReset.AccumulatorValue",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "controlType": {
+                    "label": "cim:Control.controlType",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "timeStamp": {
+                    "label": "cim:Control.timeStamp",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "unitSymbol": {
+                    "label": "cim:Control.unitSymbol",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "unitMultiplier": {
+                    "label": "cim:Control.unitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier."
+                },
+                "operationInProgress": {
+                    "label": "cim:Control.operationInProgress",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "PowerSystemResource": {
+                    "label": "cim:Control.PowerSystemResource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "AccumulatorValue": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:AccumulatorValue",
+            "fields": {
+                "Accumulator": {
+                    "label": "cim:AccumulatorValue.Accumulator",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "AccumulatorReset": {
+                    "label": "cim:AccumulatorValue.AccumulatorReset",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#AccumulatorReset.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#AccumulatorReset."
+                },
+                "value": {
+                    "label": "cim:AccumulatorValue.value",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "MeasurementValueQuality": {
+                    "label": "cim:MeasurementValue.MeasurementValueQuality",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#MeasurementValueQuality.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#MeasurementValueQuality."
+                },
+                "sensorAccuracy": {
+                    "label": "cim:MeasurementValue.sensorAccuracy",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "timeStamp": {
+                    "label": "cim:MeasurementValue.timeStamp",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "MeasurementValueSource": {
+                    "label": "cim:MeasurementValue.MeasurementValueSource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ActivePowerLimit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ActivePowerLimit",
+            "fields": {
+                "value": {
+                    "label": "cim:ActivePowerLimit.value",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "OperationalLimitType": {
+                    "label": "cim:OperationalLimit.OperationalLimitType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:OperationalLimit.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "AnalogLimit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:AnalogLimit",
+            "fields": {
+                "value": {
+                    "label": "cim:AnalogLimit.value",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "LimitSet": {
+                    "label": "cim:AnalogLimit.LimitSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "AnalogLimitSet": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:AnalogLimitSet",
+            "fields": {
+                "Limits": {
+                    "label": "cim:AnalogLimitSet.Limits",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#AnalogLimit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#AnalogLimit."
+                },
+                "Measurements": {
+                    "label": "cim:AnalogLimitSet.Measurements",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "isPercentageLimits": {
+                    "label": "cim:LimitSet.isPercentageLimits",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ApparentPowerLimit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ApparentPowerLimit",
+            "fields": {
+                "value": {
+                    "label": "cim:ApparentPowerLimit.value",
+                    "data_type": "ApparentPower",
+                    "data_type_prim": "Float"
+                },
+                "OperationalLimitType": {
+                    "label": "cim:OperationalLimit.OperationalLimitType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:OperationalLimit.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "BusNameMarker": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:BusNameMarker",
+            "fields": {
+                "priority": {
+                    "label": "cim:BusNameMarker.priority",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "Terminal": {
+                    "label": "cim:BusNameMarker.Terminal",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ACDCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ACDCTerminal."
+                },
+                "ReportingGroup": {
+                    "label": "cim:BusNameMarker.ReportingGroup",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Command": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Command",
+            "fields": {
+                "normalValue": {
+                    "label": "cim:Command.normalValue",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "DiscreteValue": {
+                    "label": "cim:Command.DiscreteValue",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ValueAliasSet": {
+                    "label": "cim:Command.ValueAliasSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "value": {
+                    "label": "cim:Command.value",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "controlType": {
+                    "label": "cim:Control.controlType",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "timeStamp": {
+                    "label": "cim:Control.timeStamp",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "unitSymbol": {
+                    "label": "cim:Control.unitSymbol",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "unitMultiplier": {
+                    "label": "cim:Control.unitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier."
+                },
+                "operationInProgress": {
+                    "label": "cim:Control.operationInProgress",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "PowerSystemResource": {
+                    "label": "cim:Control.PowerSystemResource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ConformLoadGroup": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ConformLoadGroup",
+            "fields": {
+                "ConformLoadSchedules": {
+                    "label": "cim:ConformLoadGroup.ConformLoadSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConformLoadSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConformLoadSchedule."
+                },
+                "EnergyConsumers": {
+                    "label": "cim:ConformLoadGroup.EnergyConsumers",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConformLoad.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConformLoad."
+                },
+                "SubLoadArea": {
+                    "label": "cim:LoadGroup.SubLoadArea",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ConformLoadSchedule": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ConformLoadSchedule",
+            "fields": {
+                "ConformLoadGroup": {
+                    "label": "cim:ConformLoadSchedule.ConformLoadGroup",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DayType": {
+                    "label": "cim:SeasonDayTypeSchedule.DayType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Season": {
+                    "label": "cim:SeasonDayTypeSchedule.Season",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "timeStep": {
+                    "label": "cim:RegularIntervalSchedule.timeStep",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "TimePoints": {
+                    "label": "cim:RegularIntervalSchedule.TimePoints",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegularTimePoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegularTimePoint."
+                },
+                "endTime": {
+                    "label": "cim:RegularIntervalSchedule.endTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "value2Unit": {
+                    "label": "cim:BasicIntervalSchedule.value2Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "value1Unit": {
+                    "label": "cim:BasicIntervalSchedule.value1Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "startTime": {
+                    "label": "cim:BasicIntervalSchedule.startTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ControlAreaGeneratingUnit": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ControlAreaGeneratingUnit",
+            "fields": {
+                "ControlArea": {
+                    "label": "cim:ControlAreaGeneratingUnit.ControlArea",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "GeneratingUnit": {
+                    "label": "cim:ControlAreaGeneratingUnit.GeneratingUnit",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCBreaker": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCBreaker",
+            "fields": {
+                "DCTerminals": {
+                    "label": "cim:DCConductingEquipment.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCTerminal."
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCBusbar": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCBusbar",
+            "fields": {
+                "DCTerminals": {
+                    "label": "cim:DCConductingEquipment.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCTerminal."
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCChopper": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCChopper",
+            "fields": {
+                "DCTerminals": {
+                    "label": "cim:DCConductingEquipment.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCTerminal."
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCDisconnector": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCDisconnector",
+            "fields": {
+                "DCTerminals": {
+                    "label": "cim:DCConductingEquipment.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCTerminal."
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCGround": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCGround",
+            "fields": {
+                "inductance": {
+                    "label": "cim:DCGround.inductance",
+                    "data_type": "Inductance",
+                    "data_type_prim": "Float"
+                },
+                "r": {
+                    "label": "cim:DCGround.r",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "DCTerminals": {
+                    "label": "cim:DCConductingEquipment.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCTerminal."
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCSeriesDevice": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCSeriesDevice",
+            "fields": {
+                "ratedUdc": {
+                    "label": "cim:DCSeriesDevice.ratedUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "inductance": {
+                    "label": "cim:DCSeriesDevice.inductance",
+                    "data_type": "Inductance",
+                    "data_type_prim": "Float"
+                },
+                "resistance": {
+                    "label": "cim:DCSeriesDevice.resistance",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "DCTerminals": {
+                    "label": "cim:DCConductingEquipment.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCTerminal."
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCShunt": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCShunt",
+            "fields": {
+                "capacitance": {
+                    "label": "cim:DCShunt.capacitance",
+                    "data_type": "Capacitance",
+                    "data_type_prim": "Float"
+                },
+                "resistance": {
+                    "label": "cim:DCShunt.resistance",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "ratedUdc": {
+                    "label": "cim:DCShunt.ratedUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "DCTerminals": {
+                    "label": "cim:DCConductingEquipment.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCTerminal."
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCSwitch": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCSwitch",
+            "fields": {
+                "DCTerminals": {
+                    "label": "cim:DCConductingEquipment.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCTerminal."
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DayType": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DayType",
+            "fields": {
+                "SeasonDayTypeSchedules": {
+                    "label": "cim:DayType.SeasonDayTypeSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SeasonDayTypeSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SeasonDayTypeSchedule."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Discrete": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Discrete",
+            "fields": {
+                "ValueAliasSet": {
+                    "label": "cim:Discrete.ValueAliasSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DiscreteValues": {
+                    "label": "cim:Discrete.DiscreteValues",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DiscreteValue.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DiscreteValue."
+                },
+                "phases": {
+                    "label": "cim:Measurement.phases",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode."
+                },
+                "PowerSystemResource": {
+                    "label": "cim:Measurement.PowerSystemResource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "unitSymbol": {
+                    "label": "cim:Measurement.unitSymbol",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "measurementType": {
+                    "label": "cim:Measurement.measurementType",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "Terminal": {
+                    "label": "cim:Measurement.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "unitMultiplier": {
+                    "label": "cim:Measurement.unitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DiscreteValue": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DiscreteValue",
+            "fields": {
+                "value": {
+                    "label": "cim:DiscreteValue.value",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "Command": {
+                    "label": "cim:DiscreteValue.Command",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Command.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Command."
+                },
+                "Discrete": {
+                    "label": "cim:DiscreteValue.Discrete",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "MeasurementValueQuality": {
+                    "label": "cim:MeasurementValue.MeasurementValueQuality",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#MeasurementValueQuality.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#MeasurementValueQuality."
+                },
+                "sensorAccuracy": {
+                    "label": "cim:MeasurementValue.sensorAccuracy",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "timeStamp": {
+                    "label": "cim:MeasurementValue.timeStamp",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "MeasurementValueSource": {
+                    "label": "cim:MeasurementValue.MeasurementValueSource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EquivalentNetwork": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:EquivalentNetwork",
+            "fields": {
+                "EquivalentEquipments": {
+                    "label": "cim:EquivalentNetwork.EquivalentEquipments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#EquivalentEquipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#EquivalentEquipment."
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:ConnectivityNodeContainer.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EquivalentShunt": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:EquivalentShunt",
+            "fields": {
+                "g": {
+                    "label": "cim:EquivalentShunt.g",
+                    "data_type": "Conductance",
+                    "data_type_prim": "Float"
+                },
+                "b": {
+                    "label": "cim:EquivalentShunt.b",
+                    "data_type": "Susceptance",
+                    "data_type_prim": "Float"
+                },
+                "EquivalentNetwork": {
+                    "label": "cim:EquivalentEquipment.EquivalentNetwork",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "FossilFuel": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:FossilFuel",
+            "fields": {
+                "fossilFuelType": {
+                    "label": "cim:FossilFuel.fossilFuelType",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#FuelType.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#FuelType."
+                },
+                "ThermalGeneratingUnit": {
+                    "label": "cim:FossilFuel.ThermalGeneratingUnit",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "GrossToNetActivePowerCurve": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:GrossToNetActivePowerCurve",
+            "fields": {
+                "GeneratingUnit": {
+                    "label": "cim:GrossToNetActivePowerCurve.GeneratingUnit",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "curveStyle": {
+                    "label": "cim:Curve.curveStyle",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#CurveStyle.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#CurveStyle."
+                },
+                "CurveDatas": {
+                    "label": "cim:Curve.CurveDatas",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#CurveData.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#CurveData."
+                },
+                "y2Unit": {
+                    "label": "cim:Curve.y2Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "y1Unit": {
+                    "label": "cim:Curve.y1Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "xUnit": {
+                    "label": "cim:Curve.xUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "HydroPowerPlant": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:HydroPowerPlant",
+            "fields": {
+                "hydroPlantStorageType": {
+                    "label": "cim:HydroPowerPlant.hydroPlantStorageType",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#HydroPlantStorageKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#HydroPlantStorageKind."
+                },
+                "HydroPumps": {
+                    "label": "cim:HydroPowerPlant.HydroPumps",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#HydroPump.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#HydroPump."
+                },
+                "HydroGeneratingUnits": {
+                    "label": "cim:HydroPowerPlant.HydroGeneratingUnits",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#HydroGeneratingUnit.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#HydroGeneratingUnit."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "HydroPump": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:HydroPump",
+            "fields": {
+                "HydroPowerPlant": {
+                    "label": "cim:HydroPump.HydroPowerPlant",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "RotatingMachine": {
+                    "label": "cim:HydroPump.RotatingMachine",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Junction": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Junction",
+            "fields": {
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "BaseVoltage": {
+                    "label": "cim:ConductingEquipment.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "aggregate": {
+                    "label": "cim:Equipment.aggregate",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "OperationalLimitSet": {
+                    "label": "cim:Equipment.OperationalLimitSet",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitSet."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Line": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Line",
+            "fields": {
+                "Region": {
+                    "label": "cim:Line.Region",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Equipments": {
+                    "label": "cim:EquipmentContainer.Equipments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Equipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Equipment."
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:ConnectivityNodeContainer.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode."
+                },
+                "Measurements": {
+                    "label": "cim:PowerSystemResource.Measurements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Measurement."
+                },
+                "Controls": {
+                    "label": "cim:PowerSystemResource.Controls",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Control."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "LoadArea": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:LoadArea",
+            "fields": {
+                "SubLoadAreas": {
+                    "label": "cim:LoadArea.SubLoadAreas",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SubLoadArea.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SubLoadArea."
+                },
+                "ControlArea": {
+                    "label": "cim:EnergyArea.ControlArea",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlArea.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlArea."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "LoadResponseCharacteristic": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:LoadResponseCharacteristic",
+            "fields": {
+                "qConstantImpedance": {
+                    "label": "cim:LoadResponseCharacteristic.qConstantImpedance",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "qVoltageExponent": {
+                    "label": "cim:LoadResponseCharacteristic.qVoltageExponent",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "qFrequencyExponent": {
+                    "label": "cim:LoadResponseCharacteristic.qFrequencyExponent",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "qConstantPower": {
+                    "label": "cim:LoadResponseCharacteristic.qConstantPower",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "pConstantImpedance": {
+                    "label": "cim:LoadResponseCharacteristic.pConstantImpedance",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "pVoltageExponent": {
+                    "label": "cim:LoadResponseCharacteristic.pVoltageExponent",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "EnergyConsumer": {
+                    "label": "cim:LoadResponseCharacteristic.EnergyConsumer",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#EnergyConsumer.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#EnergyConsumer."
+                },
+                "pConstantPower": {
+                    "label": "cim:LoadResponseCharacteristic.pConstantPower",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "qConstantCurrent": {
+                    "label": "cim:LoadResponseCharacteristic.qConstantCurrent",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "pConstantCurrent": {
+                    "label": "cim:LoadResponseCharacteristic.pConstantCurrent",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "pFrequencyExponent": {
+                    "label": "cim:LoadResponseCharacteristic.pFrequencyExponent",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "exponentModel": {
+                    "label": "cim:LoadResponseCharacteristic.exponentModel",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "MeasurementValueQuality": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:MeasurementValueQuality",
+            "fields": {
+                "MeasurementValue": {
+                    "label": "cim:MeasurementValueQuality.MeasurementValue",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "outOfRange": {
+                    "label": "cim:Quality61850.outOfRange",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "overFlow": {
+                    "label": "cim:Quality61850.overFlow",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "failure": {
+                    "label": "cim:Quality61850.failure",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "suspect": {
+                    "label": "cim:Quality61850.suspect",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "test": {
+                    "label": "cim:Quality61850.test",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "validity": {
+                    "label": "cim:Quality61850.validity",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Validity.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Validity."
+                },
+                "badReference": {
+                    "label": "cim:Quality61850.badReference",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "estimatorReplaced": {
+                    "label": "cim:Quality61850.estimatorReplaced",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "operatorBlocked": {
+                    "label": "cim:Quality61850.operatorBlocked",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "oldData": {
+                    "label": "cim:Quality61850.oldData",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "oscillatory": {
+                    "label": "cim:Quality61850.oscillatory",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "source": {
+                    "label": "cim:Quality61850.source",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Source.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Source."
+                }
+            }
+        },
+        "NonConformLoadGroup": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:NonConformLoadGroup",
+            "fields": {
+                "EnergyConsumers": {
+                    "label": "cim:NonConformLoadGroup.EnergyConsumers",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#NonConformLoad.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#NonConformLoad."
+                },
+                "NonConformLoadSchedules": {
+                    "label": "cim:NonConformLoadGroup.NonConformLoadSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#NonConformLoadSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#NonConformLoadSchedule."
+                },
+                "SubLoadArea": {
+                    "label": "cim:LoadGroup.SubLoadArea",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "NonConformLoadSchedule": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:NonConformLoadSchedule",
+            "fields": {
+                "NonConformLoadGroup": {
+                    "label": "cim:NonConformLoadSchedule.NonConformLoadGroup",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DayType": {
+                    "label": "cim:SeasonDayTypeSchedule.DayType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Season": {
+                    "label": "cim:SeasonDayTypeSchedule.Season",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "timeStep": {
+                    "label": "cim:RegularIntervalSchedule.timeStep",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "TimePoints": {
+                    "label": "cim:RegularIntervalSchedule.TimePoints",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegularTimePoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegularTimePoint."
+                },
+                "endTime": {
+                    "label": "cim:RegularIntervalSchedule.endTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "value2Unit": {
+                    "label": "cim:BasicIntervalSchedule.value2Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "value1Unit": {
+                    "label": "cim:BasicIntervalSchedule.value1Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "startTime": {
+                    "label": "cim:BasicIntervalSchedule.startTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PerLengthDCLineParameter": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PerLengthDCLineParameter",
+            "fields": {
+                "capacitance": {
+                    "label": "cim:PerLengthDCLineParameter.capacitance",
+                    "data_type": "CapacitancePerLength",
+                    "data_type_prim": "Float"
+                },
+                "inductance": {
+                    "label": "cim:PerLengthDCLineParameter.inductance",
+                    "data_type": "InductancePerLength",
+                    "data_type_prim": "Float"
+                },
+                "DCLineSegments": {
+                    "label": "cim:PerLengthDCLineParameter.DCLineSegments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCLineSegment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCLineSegment."
+                },
+                "resistance": {
+                    "label": "cim:PerLengthDCLineParameter.resistance",
+                    "data_type": "ResistancePerLength",
+                    "data_type_prim": "Float"
+                }
+            }
+        },
+        "PhaseTapChangerTable": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PhaseTapChangerTable",
+            "fields": {
+                "PhaseTapChangerTabular": {
+                    "label": "cim:PhaseTapChangerTable.PhaseTapChangerTabular",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseTapChangerTabular.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseTapChangerTabular."
+                },
+                "PhaseTapChangerTablePoint": {
+                    "label": "cim:PhaseTapChangerTable.PhaseTapChangerTablePoint",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseTapChangerTablePoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseTapChangerTablePoint."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "RaiseLowerCommand": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:RaiseLowerCommand",
+            "fields": {
+                "ValueAliasSet": {
+                    "label": "cim:RaiseLowerCommand.ValueAliasSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "minValue": {
+                    "label": "cim:AnalogControl.minValue",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "AnalogValue": {
+                    "label": "cim:AnalogControl.AnalogValue",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "maxValue": {
+                    "label": "cim:AnalogControl.maxValue",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "controlType": {
+                    "label": "cim:Control.controlType",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "timeStamp": {
+                    "label": "cim:Control.timeStamp",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "unitSymbol": {
+                    "label": "cim:Control.unitSymbol",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "unitMultiplier": {
+                    "label": "cim:Control.unitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier."
+                },
+                "operationInProgress": {
+                    "label": "cim:Control.operationInProgress",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "PowerSystemResource": {
+                    "label": "cim:Control.PowerSystemResource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "RegularTimePoint": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:RegularTimePoint",
+            "fields": {
+                "value2": {
+                    "label": "cim:RegularTimePoint.value2",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "IntervalSchedule": {
+                    "label": "cim:RegularTimePoint.IntervalSchedule",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "value1": {
+                    "label": "cim:RegularTimePoint.value1",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "sequenceNumber": {
+                    "label": "cim:RegularTimePoint.sequenceNumber",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                }
+            }
+        },
+        "RegulationSchedule": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:RegulationSchedule",
+            "fields": {
+                "RegulatingControl": {
+                    "label": "cim:RegulationSchedule.RegulatingControl",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DayType": {
+                    "label": "cim:SeasonDayTypeSchedule.DayType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Season": {
+                    "label": "cim:SeasonDayTypeSchedule.Season",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "timeStep": {
+                    "label": "cim:RegularIntervalSchedule.timeStep",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "TimePoints": {
+                    "label": "cim:RegularIntervalSchedule.TimePoints",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegularTimePoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegularTimePoint."
+                },
+                "endTime": {
+                    "label": "cim:RegularIntervalSchedule.endTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "value2Unit": {
+                    "label": "cim:BasicIntervalSchedule.value2Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "value1Unit": {
+                    "label": "cim:BasicIntervalSchedule.value1Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "startTime": {
+                    "label": "cim:BasicIntervalSchedule.startTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ReportingGroup": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ReportingGroup",
+            "fields": {
+                "BusNameMarker": {
+                    "label": "cim:ReportingGroup.BusNameMarker",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#BusNameMarker.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#BusNameMarker."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Season": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Season",
+            "fields": {
+                "endDate": {
+                    "label": "cim:Season.endDate",
+                    "data_type": "MonthDay",
+                    "data_type_prim": "MonthDay"
+                },
+                "SeasonDayTypeSchedules": {
+                    "label": "cim:Season.SeasonDayTypeSchedules",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SeasonDayTypeSchedule.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SeasonDayTypeSchedule."
+                },
+                "startDate": {
+                    "label": "cim:Season.startDate",
+                    "data_type": "MonthDay",
+                    "data_type_prim": "MonthDay"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SetPoint": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SetPoint",
+            "fields": {
+                "normalValue": {
+                    "label": "cim:SetPoint.normalValue",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "value": {
+                    "label": "cim:SetPoint.value",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "minValue": {
+                    "label": "cim:AnalogControl.minValue",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "AnalogValue": {
+                    "label": "cim:AnalogControl.AnalogValue",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "maxValue": {
+                    "label": "cim:AnalogControl.maxValue",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "controlType": {
+                    "label": "cim:Control.controlType",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "timeStamp": {
+                    "label": "cim:Control.timeStamp",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "unitSymbol": {
+                    "label": "cim:Control.unitSymbol",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "unitMultiplier": {
+                    "label": "cim:Control.unitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier."
+                },
+                "operationInProgress": {
+                    "label": "cim:Control.operationInProgress",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "PowerSystemResource": {
+                    "label": "cim:Control.PowerSystemResource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "StringMeasurement": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:StringMeasurement",
+            "fields": {
+                "StringMeasurementValues": {
+                    "label": "cim:StringMeasurement.StringMeasurementValues",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#StringMeasurementValue.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#StringMeasurementValue."
+                },
+                "phases": {
+                    "label": "cim:Measurement.phases",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode."
+                },
+                "PowerSystemResource": {
+                    "label": "cim:Measurement.PowerSystemResource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "unitSymbol": {
+                    "label": "cim:Measurement.unitSymbol",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "measurementType": {
+                    "label": "cim:Measurement.measurementType",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "Terminal": {
+                    "label": "cim:Measurement.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "unitMultiplier": {
+                    "label": "cim:Measurement.unitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "StringMeasurementValue": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:StringMeasurementValue",
+            "fields": {
+                "StringMeasurement": {
+                    "label": "cim:StringMeasurementValue.StringMeasurement",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "value": {
+                    "label": "cim:StringMeasurementValue.value",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "MeasurementValueQuality": {
+                    "label": "cim:MeasurementValue.MeasurementValueQuality",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#MeasurementValueQuality.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#MeasurementValueQuality."
+                },
+                "sensorAccuracy": {
+                    "label": "cim:MeasurementValue.sensorAccuracy",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "timeStamp": {
+                    "label": "cim:MeasurementValue.timeStamp",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "MeasurementValueSource": {
+                    "label": "cim:MeasurementValue.MeasurementValueSource",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SubLoadArea": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SubLoadArea",
+            "fields": {
+                "LoadGroups": {
+                    "label": "cim:SubLoadArea.LoadGroups",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#LoadGroup.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#LoadGroup."
+                },
+                "LoadArea": {
+                    "label": "cim:SubLoadArea.LoadArea",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ControlArea": {
+                    "label": "cim:EnergyArea.ControlArea",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlArea.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ControlArea."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SwitchSchedule": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SwitchSchedule",
+            "fields": {
+                "Switch": {
+                    "label": "cim:SwitchSchedule.Switch",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DayType": {
+                    "label": "cim:SeasonDayTypeSchedule.DayType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Season": {
+                    "label": "cim:SeasonDayTypeSchedule.Season",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "timeStep": {
+                    "label": "cim:RegularIntervalSchedule.timeStep",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "TimePoints": {
+                    "label": "cim:RegularIntervalSchedule.TimePoints",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegularTimePoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegularTimePoint."
+                },
+                "endTime": {
+                    "label": "cim:RegularIntervalSchedule.endTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "value2Unit": {
+                    "label": "cim:BasicIntervalSchedule.value2Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "value1Unit": {
+                    "label": "cim:BasicIntervalSchedule.value1Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "startTime": {
+                    "label": "cim:BasicIntervalSchedule.startTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "TapSchedule": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:TapSchedule",
+            "fields": {
+                "TapChanger": {
+                    "label": "cim:TapSchedule.TapChanger",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DayType": {
+                    "label": "cim:SeasonDayTypeSchedule.DayType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Season": {
+                    "label": "cim:SeasonDayTypeSchedule.Season",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "timeStep": {
+                    "label": "cim:RegularIntervalSchedule.timeStep",
+                    "data_type": "Seconds",
+                    "data_type_prim": "Float"
+                },
+                "TimePoints": {
+                    "label": "cim:RegularIntervalSchedule.TimePoints",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegularTimePoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RegularTimePoint."
+                },
+                "endTime": {
+                    "label": "cim:RegularIntervalSchedule.endTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "value2Unit": {
+                    "label": "cim:BasicIntervalSchedule.value2Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "value1Unit": {
+                    "label": "cim:BasicIntervalSchedule.value1Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "startTime": {
+                    "label": "cim:BasicIntervalSchedule.startTime",
+                    "data_type": "DateTime",
+                    "data_type_prim": "DateTime"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ValueAliasSet": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ValueAliasSet",
+            "fields": {
+                "RaiseLowerCommands": {
+                    "label": "cim:ValueAliasSet.RaiseLowerCommands",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RaiseLowerCommand.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#RaiseLowerCommand."
+                },
+                "Commands": {
+                    "label": "cim:ValueAliasSet.Commands",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Command.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Command."
+                },
+                "Discretes": {
+                    "label": "cim:ValueAliasSet.Discretes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Discrete.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Discrete."
+                },
+                "Values": {
+                    "label": "cim:ValueAliasSet.Values",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ValueToAlias.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ValueToAlias."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ValueToAlias": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ValueToAlias",
+            "fields": {
+                "ValueAliasSet": {
+                    "label": "cim:ValueToAlias.ValueAliasSet",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "value": {
+                    "label": "cim:ValueToAlias.value",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "VsCapabilityCurve": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:VsCapabilityCurve",
+            "fields": {
+                "VsConverterDCSides": {
+                    "label": "cim:VsCapabilityCurve.VsConverterDCSides",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#VsConverter.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#VsConverter."
+                },
+                "curveStyle": {
+                    "label": "cim:Curve.curveStyle",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#CurveStyle.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#CurveStyle."
+                },
+                "CurveDatas": {
+                    "label": "cim:Curve.CurveDatas",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#CurveData.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#CurveData."
+                },
+                "y2Unit": {
+                    "label": "cim:Curve.y2Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "y1Unit": {
+                    "label": "cim:Curve.y1Unit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "xUnit": {
+                    "label": "cim:Curve.xUnit",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol."
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        }
+    },
+    "eq_bd": {
+        "ConnectivityNode": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:ConnectivityNode",
+            "fields": {
+                "boundaryPoint": {
+                    "label": "entsoe:ConnectivityNode.boundaryPoint",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "fromEndIsoCode": {
+                    "label": "entsoe:ConnectivityNode.fromEndIsoCode",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "fromEndName": {
+                    "label": "entsoe:ConnectivityNode.fromEndName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "fromEndNameTso": {
+                    "label": "entsoe:ConnectivityNode.fromEndNameTso",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "toEndIsoCode": {
+                    "label": "entsoe:ConnectivityNode.toEndIsoCode",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "toEndName": {
+                    "label": "entsoe:ConnectivityNode.toEndName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "toEndNameTso": {
+                    "label": "entsoe:ConnectivityNode.toEndNameTso",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "ConnectivityNodeContainer": {
+                    "label": "cim:ConnectivityNode.ConnectivityNodeContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "BaseVoltage": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:BaseVoltage",
+            "fields": {
+                "nominalVoltage": {
+                    "label": "cim:BaseVoltage.nominalVoltage",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Terminal": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Terminal",
+            "fields": {
+                "ConductingEquipment": {
+                    "label": "cim:Terminal.ConductingEquipment",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                }
+            }
+        },
+        "EnergySource": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:EnergySource",
+            "fields": {
+                "EnergySchedulingType": {
+                    "label": "cim:EnergySource.EnergySchedulingType",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EnergySchedulingType": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "entsoe:EnergySchedulingType",
+            "fields": {
+                "EnergySource": {
+                    "label": "cim:EnergySchedulingType.EnergySource",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#EnergySource.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#EnergySource."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "FullModel": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:FullModel",
+            "fields": {}
+        },
+        "GeographicalRegion": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:GeographicalRegion",
+            "fields": {
+                "Regions": {
+                    "label": "cim:GeographicalRegion.Regions",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SubGeographicalRegion.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SubGeographicalRegion."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Junction": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Junction",
+            "fields": {
+                "Terminals": {
+                    "label": "cim:ConductingEquipment.Terminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "EquipmentContainer": {
+                    "label": "cim:Equipment.EquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Line": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Line",
+            "fields": {
+                "Region": {
+                    "label": "cim:Line.Region",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Equipments": {
+                    "label": "cim:EquipmentContainer.Equipments",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Equipment.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Equipment."
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:ConnectivityNodeContainer.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SubGeographicalRegion": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SubGeographicalRegion",
+            "fields": {
+                "Region": {
+                    "label": "cim:SubGeographicalRegion.Region",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Lines": {
+                    "label": "cim:SubGeographicalRegion.Lines",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Line.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Line."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        }
+    },
+    "ssh": {
+        "ControlArea": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ControlArea",
+            "fields": {
+                "netInterchange": {
+                    "label": "cim:ControlArea.netInterchange",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "pTolerance": {
+                    "label": "cim:ControlArea.pTolerance",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ExternalNetworkInjection": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ExternalNetworkInjection",
+            "fields": {
+                "referencePriority": {
+                    "label": "cim:ExternalNetworkInjection.referencePriority",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "p": {
+                    "label": "cim:ExternalNetworkInjection.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:ExternalNetworkInjection.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "controlEnabled": {
+                    "label": "cim:RegulatingCondEq.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Terminal": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:Terminal",
+            "fields": {
+                "connected": {
+                    "label": "cim:ACDCTerminal.connected",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCTerminal": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:DCTerminal",
+            "fields": {
+                "connected": {
+                    "label": "cim:ACDCTerminal.connected",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ACDCConverterDCTerminal": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ACDCConverterDCTerminal",
+            "fields": {
+                "connected": {
+                    "label": "cim:ACDCTerminal.connected",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "CsConverter": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:CsConverter",
+            "fields": {
+                "operatingMode": {
+                    "label": "cim:CsConverter.operatingMode",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#CsOperatingModeKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#CsOperatingModeKind."
+                },
+                "pPccControl": {
+                    "label": "cim:CsConverter.pPccControl",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#CsPpccControlKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#CsPpccControlKind."
+                },
+                "targetAlpha": {
+                    "label": "cim:CsConverter.targetAlpha",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "targetGamma": {
+                    "label": "cim:CsConverter.targetGamma",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "targetIdc": {
+                    "label": "cim:CsConverter.targetIdc",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "p": {
+                    "label": "cim:ACDCConverter.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:ACDCConverter.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "targetPpcc": {
+                    "label": "cim:ACDCConverter.targetPpcc",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "targetUdc": {
+                    "label": "cim:ACDCConverter.targetUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "VsConverter": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:VsConverter",
+            "fields": {
+                "droop": {
+                    "label": "cim:VsConverter.droop",
+                    "data_type": "PU",
+                    "data_type_prim": "Float"
+                },
+                "droopCompensation": {
+                    "label": "cim:VsConverter.droopCompensation",
+                    "data_type": "Resistance",
+                    "data_type_prim": "Float"
+                },
+                "pPccControl": {
+                    "label": "cim:VsConverter.pPccControl",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#VsPpccControlKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#VsPpccControlKind."
+                },
+                "qPccControl": {
+                    "label": "cim:VsConverter.qPccControl",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#VsQpccControlKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#VsQpccControlKind."
+                },
+                "qShare": {
+                    "label": "cim:VsConverter.qShare",
+                    "data_type": "PerCent",
+                    "data_type_prim": "Float"
+                },
+                "targetQpcc": {
+                    "label": "cim:VsConverter.targetQpcc",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "targetUpcc": {
+                    "label": "cim:VsConverter.targetUpcc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "p": {
+                    "label": "cim:ACDCConverter.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:ACDCConverter.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "targetPpcc": {
+                    "label": "cim:ACDCConverter.targetPpcc",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "targetUdc": {
+                    "label": "cim:ACDCConverter.targetUdc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Breaker": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:Breaker",
+            "fields": {
+                "open": {
+                    "label": "cim:Switch.open",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Disconnector": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:Disconnector",
+            "fields": {
+                "open": {
+                    "label": "cim:Switch.open",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Switch": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:Switch",
+            "fields": {
+                "open": {
+                    "label": "cim:Switch.open",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "LoadBreakSwitch": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:LoadBreakSwitch",
+            "fields": {
+                "open": {
+                    "label": "cim:Switch.open",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EnergyConsumer": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:EnergyConsumer",
+            "fields": {
+                "p": {
+                    "label": "cim:EnergyConsumer.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:EnergyConsumer.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ConformLoad": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ConformLoad",
+            "fields": {
+                "p": {
+                    "label": "cim:EnergyConsumer.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:EnergyConsumer.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "NonConformLoad": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:NonConformLoad",
+            "fields": {
+                "p": {
+                    "label": "cim:EnergyConsumer.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:EnergyConsumer.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "StationSupply": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:StationSupply",
+            "fields": {
+                "p": {
+                    "label": "cim:EnergyConsumer.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:EnergyConsumer.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "RegulatingControl": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:RegulatingControl",
+            "fields": {
+                "discrete": {
+                    "label": "cim:RegulatingControl.discrete",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "enabled": {
+                    "label": "cim:RegulatingControl.enabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "targetDeadband": {
+                    "label": "cim:RegulatingControl.targetDeadband",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "targetValue": {
+                    "label": "cim:RegulatingControl.targetValue",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "targetValueUnitMultiplier": {
+                    "label": "cim:RegulatingControl.targetValueUnitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier."
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SynchronousMachine": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:SynchronousMachine",
+            "fields": {
+                "operatingMode": {
+                    "label": "cim:SynchronousMachine.operatingMode",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode."
+                },
+                "referencePriority": {
+                    "label": "cim:SynchronousMachine.referencePriority",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "p": {
+                    "label": "cim:RotatingMachine.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:RotatingMachine.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "controlEnabled": {
+                    "label": "cim:RegulatingCondEq.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "GeneratingUnit": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:GeneratingUnit",
+            "fields": {
+                "normalPF": {
+                    "label": "cim:GeneratingUnit.normalPF",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "AsynchronousMachine": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:AsynchronousMachine",
+            "fields": {
+                "asynchronousMachineType": {
+                    "label": "cim:AsynchronousMachine.asynchronousMachineType",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#AsynchronousMachineKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#AsynchronousMachineKind."
+                },
+                "p": {
+                    "label": "cim:RotatingMachine.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:RotatingMachine.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "controlEnabled": {
+                    "label": "cim:RegulatingCondEq.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EnergySource": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:EnergySource",
+            "fields": {
+                "activePower": {
+                    "label": "cim:EnergySource.activePower",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "reactivePower": {
+                    "label": "cim:EnergySource.reactivePower",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "StaticVarCompensator": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:StaticVarCompensator",
+            "fields": {
+                "q": {
+                    "label": "cim:StaticVarCompensator.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "controlEnabled": {
+                    "label": "cim:RegulatingCondEq.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "TapChangerControl": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:TapChangerControl",
+            "fields": {
+                "discrete": {
+                    "label": "cim:RegulatingControl.discrete",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "enabled": {
+                    "label": "cim:RegulatingControl.enabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "targetDeadband": {
+                    "label": "cim:RegulatingControl.targetDeadband",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "targetValue": {
+                    "label": "cim:RegulatingControl.targetValue",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "targetValueUnitMultiplier": {
+                    "label": "cim:RegulatingControl.targetValueUnitMultiplier",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier."
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "RatioTapChanger": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:RatioTapChanger",
+            "fields": {
+                "controlEnabled": {
+                    "label": "cim:TapChanger.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "step": {
+                    "label": "cim:TapChanger.step",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerLinear": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:PhaseTapChangerLinear",
+            "fields": {
+                "controlEnabled": {
+                    "label": "cim:TapChanger.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "step": {
+                    "label": "cim:TapChanger.step",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerAsymmetrical": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:PhaseTapChangerAsymmetrical",
+            "fields": {
+                "controlEnabled": {
+                    "label": "cim:TapChanger.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "step": {
+                    "label": "cim:TapChanger.step",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerSymmetrical": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:PhaseTapChangerSymmetrical",
+            "fields": {
+                "controlEnabled": {
+                    "label": "cim:TapChanger.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "step": {
+                    "label": "cim:TapChanger.step",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PhaseTapChangerTabular": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:PhaseTapChangerTabular",
+            "fields": {
+                "controlEnabled": {
+                    "label": "cim:TapChanger.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "step": {
+                    "label": "cim:TapChanger.step",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "LinearShuntCompensator": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:LinearShuntCompensator",
+            "fields": {
+                "sections": {
+                    "label": "cim:ShuntCompensator.sections",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "controlEnabled": {
+                    "label": "cim:RegulatingCondEq.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "NonlinearShuntCompensator": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:NonlinearShuntCompensator",
+            "fields": {
+                "sections": {
+                    "label": "cim:ShuntCompensator.sections",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "controlEnabled": {
+                    "label": "cim:RegulatingCondEq.controlEnabled",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "EquivalentInjection": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:EquivalentInjection",
+            "fields": {
+                "regulationStatus": {
+                    "label": "cim:EquivalentInjection.regulationStatus",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "regulationTarget": {
+                    "label": "cim:EquivalentInjection.regulationTarget",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "p": {
+                    "label": "cim:EquivalentInjection.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:EquivalentInjection.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "FullModel": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:FullModel",
+            "fields": {}
+        },
+        "HydroGeneratingUnit": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:HydroGeneratingUnit",
+            "fields": {
+                "normalPF": {
+                    "label": "cim:GeneratingUnit.normalPF",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "NuclearGeneratingUnit": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:NuclearGeneratingUnit",
+            "fields": {
+                "normalPF": {
+                    "label": "cim:GeneratingUnit.normalPF",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SolarGeneratingUnit": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:SolarGeneratingUnit",
+            "fields": {
+                "normalPF": {
+                    "label": "cim:GeneratingUnit.normalPF",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ThermalGeneratingUnit": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ThermalGeneratingUnit",
+            "fields": {
+                "normalPF": {
+                    "label": "cim:GeneratingUnit.normalPF",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "WindGeneratingUnit": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:WindGeneratingUnit",
+            "fields": {
+                "normalPF": {
+                    "label": "cim:GeneratingUnit.normalPF",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        }
+    },
+    "sv": {
+        "SvVoltage": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SvVoltage",
+            "fields": {
+                "angle": {
+                    "label": "cim:SvVoltage.angle",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "v": {
+                    "label": "cim:SvVoltage.v",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "TopologicalNode": {
+                    "label": "cim:SvVoltage.TopologicalNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                }
+            }
+        },
+        "SvPowerFlow": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SvPowerFlow",
+            "fields": {
+                "Terminal": {
+                    "label": "cim:SvPowerFlow.Terminal",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "p": {
+                    "label": "cim:SvPowerFlow.p",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "q": {
+                    "label": "cim:SvPowerFlow.q",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                }
+            }
+        },
+        "SvShuntCompensatorSections": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SvShuntCompensatorSections",
+            "fields": {
+                "sections": {
+                    "label": "cim:SvShuntCompensatorSections.sections",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "ShuntCompensator": {
+                    "label": "cim:SvShuntCompensatorSections.ShuntCompensator",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                }
+            }
+        },
+        "SvTapStep": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SvTapStep",
+            "fields": {
+                "position": {
+                    "label": "cim:SvTapStep.position",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "TapChanger": {
+                    "label": "cim:SvTapStep.TapChanger",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                }
+            }
+        },
+        "FullModel": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:FullModel",
+            "fields": {}
+        },
+        "CsConverter": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:CsConverter",
+            "fields": {
+                "alpha": {
+                    "label": "cim:CsConverter.alpha",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "gamma": {
+                    "label": "cim:CsConverter.gamma",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "idc": {
+                    "label": "cim:ACDCConverter.idc",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "poleLossP": {
+                    "label": "cim:ACDCConverter.poleLossP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "uc": {
+                    "label": "cim:ACDCConverter.uc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "udc": {
+                    "label": "cim:ACDCConverter.udc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "SvStatus": {
+                    "label": "cim:ConductingEquipment.SvStatus",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SvStatus.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SvStatus."
+                }
+            }
+        },
+        "DCTopologicalIsland": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCTopologicalIsland",
+            "fields": {
+                "DCTopologicalNodes": {
+                    "label": "cim:DCTopologicalIsland.DCTopologicalNodes",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "SvInjection": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SvInjection",
+            "fields": {
+                "pInjection": {
+                    "label": "cim:SvInjection.pInjection",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "qInjection": {
+                    "label": "cim:SvInjection.qInjection",
+                    "data_type": "ReactivePower",
+                    "data_type_prim": "Float"
+                },
+                "TopologicalNode": {
+                    "label": "cim:SvInjection.TopologicalNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                }
+            }
+        },
+        "SvStatus": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:SvStatus",
+            "fields": {
+                "ConductingEquipment": {
+                    "label": "cim:SvStatus.ConductingEquipment",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "inService": {
+                    "label": "cim:SvStatus.inService",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                }
+            }
+        },
+        "TopologicalIsland": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:TopologicalIsland",
+            "fields": {
+                "AngleRefTopologicalNode": {
+                    "label": "cim:TopologicalIsland.AngleRefTopologicalNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "TopologicalNodes": {
+                    "label": "cim:TopologicalIsland.TopologicalNodes",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "VsConverter": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:VsConverter",
+            "fields": {
+                "delta": {
+                    "label": "cim:VsConverter.delta",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "uf": {
+                    "label": "cim:VsConverter.uf",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "idc": {
+                    "label": "cim:ACDCConverter.idc",
+                    "data_type": "CurrentFlow",
+                    "data_type_prim": "Float"
+                },
+                "poleLossP": {
+                    "label": "cim:ACDCConverter.poleLossP",
+                    "data_type": "ActivePower",
+                    "data_type_prim": "Float"
+                },
+                "uc": {
+                    "label": "cim:ACDCConverter.uc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "udc": {
+                    "label": "cim:ACDCConverter.udc",
+                    "data_type": "Voltage",
+                    "data_type_prim": "Float"
+                },
+                "SvStatus": {
+                    "label": "cim:ConductingEquipment.SvStatus",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SvStatus.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#SvStatus."
+                }
+            }
+        }
+    },
+    "tp": {
+        "TopologicalNode": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:TopologicalNode",
+            "fields": {
+                "BaseVoltage": {
+                    "label": "cim:TopologicalNode.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:TopologicalNode.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode."
+                },
+                "ConnectivityNodeContainer": {
+                    "label": "cim:TopologicalNode.ConnectivityNodeContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ReportingGroup": {
+                    "label": "cim:TopologicalNode.ReportingGroup",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "Terminal": {
+                    "label": "cim:TopologicalNode.Terminal",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Terminal."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCTopologicalNode": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DCTopologicalNode",
+            "fields": {
+                "DCTerminals": {
+                    "label": "cim:DCTopologicalNode.DCTerminals",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCBaseTerminal.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCBaseTerminal."
+                },
+                "DCEquipmentContainer": {
+                    "label": "cim:DCTopologicalNode.DCEquipmentContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DCNodes": {
+                    "label": "cim:DCTopologicalNode.DCNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DCNode."
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ConnectivityNode": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ConnectivityNode",
+            "fields": {
+                "TopologicalNode": {
+                    "label": "cim:ConnectivityNode.TopologicalNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                }
+            }
+        },
+        "Terminal": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:Terminal",
+            "fields": {
+                "TopologicalNode": {
+                    "label": "cim:Terminal.TopologicalNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DCTerminal": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:DCTerminal",
+            "fields": {
+                "DCTopologicalNode": {
+                    "label": "cim:DCBaseTerminal.DCTopologicalNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ACDCConverterDCTerminal": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ACDCConverterDCTerminal",
+            "fields": {
+                "DCTopologicalNode": {
+                    "label": "cim:DCBaseTerminal.DCTopologicalNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "FullModel": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:FullModel",
+            "fields": {}
+        },
+        "DCNode": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:DCNode",
+            "fields": {
+                "DCTopologicalNode": {
+                    "label": "cim:DCNode.DCTopologicalNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        }
+    },
+    "tp_bd": {
+        "TopologicalNode": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:TopologicalNode",
+            "fields": {
+                "BaseVoltage": {
+                    "label": "cim:TopologicalNode.BaseVoltage",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "ConnectivityNodes": {
+                    "label": "cim:TopologicalNode.ConnectivityNodes",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#ConnectivityNode."
+                },
+                "ConnectivityNodeContainer": {
+                    "label": "cim:TopologicalNode.ConnectivityNodeContainer",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "boundaryPoint": {
+                    "label": "entsoe:TopologicalNode.boundaryPoint",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "fromEndIsoCode": {
+                    "label": "entsoe:TopologicalNode.fromEndIsoCode",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "fromEndName": {
+                    "label": "entsoe:TopologicalNode.fromEndName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "fromEndNameTso": {
+                    "label": "entsoe:TopologicalNode.fromEndNameTso",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "toEndIsoCode": {
+                    "label": "entsoe:TopologicalNode.toEndIsoCode",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "toEndName": {
+                    "label": "entsoe:TopologicalNode.toEndName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "toEndNameTso": {
+                    "label": "entsoe:TopologicalNode.toEndNameTso",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "description": {
+                    "label": "cim:IdentifiedObject.description",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "energyIdentCodeEic": {
+                    "label": "entsoe:IdentifiedObject.energyIdentCodeEic",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "shortName": {
+                    "label": "entsoe:IdentifiedObject.shortName",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "ConnectivityNode": {
+            "rdf_type": " rdf:about=\"#",
+            "label": "cim:ConnectivityNode",
+            "fields": {
+                "TopologicalNode": {
+                    "label": "cim:ConnectivityNode.TopologicalNode",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                }
+            }
+        },
+        "FullModel": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:FullModel",
+            "fields": {}
+        }
+    },
+    "dl": {
+        "Diagram": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Diagram",
+            "fields": {
+                "DiagramStyle": {
+                    "label": "cim:Diagram.DiagramStyle",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "orientation": {
+                    "label": "cim:Diagram.orientation",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OrientationKind.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#OrientationKind."
+                },
+                "x1InitialView": {
+                    "label": "cim:Diagram.x1InitialView",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "x2InitialView": {
+                    "label": "cim:Diagram.x2InitialView",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "y1InitialView": {
+                    "label": "cim:Diagram.y1InitialView",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "y2InitialView": {
+                    "label": "cim:Diagram.y2InitialView",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "DiagramElements": {
+                    "label": "cim:Diagram.DiagramElements",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DiagramObject.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DiagramObject."
+                },
+                "DiagramObjects": {
+                    "label": "cim:IdentifiedObject.DiagramObjects",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DiagramObject.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DiagramObject."
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DiagramObject": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DiagramObject",
+            "fields": {
+                "Diagram": {
+                    "label": "cim:DiagramObject.Diagram",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "drawingOrder": {
+                    "label": "cim:DiagramObject.drawingOrder",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "isPolygon": {
+                    "label": "cim:DiagramObject.isPolygon",
+                    "data_type": "Boolean",
+                    "data_type_prim": "Boolean"
+                },
+                "offsetX": {
+                    "label": "cim:DiagramObject.offsetX",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "offsetY": {
+                    "label": "cim:DiagramObject.offsetY",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "rotation": {
+                    "label": "cim:DiagramObject.rotation",
+                    "data_type": "AngleDegrees",
+                    "data_type_prim": "Float"
+                },
+                "IdentifiedObject": {
+                    "label": "cim:DiagramObject.IdentifiedObject",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DiagramObjectPoints": {
+                    "label": "cim:DiagramObject.DiagramObjectPoints",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DiagramObjectPoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DiagramObjectPoint."
+                },
+                "VisibilityLayers": {
+                    "label": "cim:DiagramObject.VisibilityLayers",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#VisibilityLayer.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#VisibilityLayer."
+                },
+                "DiagramObjectStyle": {
+                    "label": "cim:DiagramObject.DiagramObjectStyle",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DiagramObjects": {
+                    "label": "cim:IdentifiedObject.DiagramObjects",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DiagramObject.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#DiagramObject."
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "DiagramObjectPoint": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:DiagramObjectPoint",
+            "fields": {
+                "DiagramObject": {
+                    "label": "cim:DiagramObjectPoint.DiagramObject",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "DiagramObjectGluePoint": {
+                    "label": "cim:DiagramObjectPoint.DiagramObjectGluePoint",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "sequenceNumber": {
+                    "label": "cim:DiagramObjectPoint.sequenceNumber",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "xPosition": {
+                    "label": "cim:DiagramObjectPoint.xPosition",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "yPosition": {
+                    "label": "cim:DiagramObjectPoint.yPosition",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                },
+                "zPosition": {
+                    "label": "cim:DiagramObjectPoint.zPosition",
+                    "data_type": "Simple_Float",
+                    "data_type_prim": "Float"
+                }
+            }
+        }
+    },
+    "gl": {
+        "CoordinateSystem": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:CoordinateSystem",
+            "fields": {
+                "crsUrn": {
+                    "label": "cim:CoordinateSystem.crsUrn",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "Location": {
+                    "label": "cim:CoordinateSystem.Location",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Location.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#Location."
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "Location": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:Location",
+            "fields": {
+                "CoordinateSystem": {
+                    "label": "cim:Location.CoordinateSystem",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "PowerSystemResources": {
+                    "label": "cim:Location.PowerSystemResources",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "PositionPoints": {
+                    "label": "cim:Location.PositionPoints",
+                    "data_type": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PositionPoint.",
+                    "data_type_prim": " rdf:resource=\"http://iec.ch/TC57/2013/CIM-schema-cim16#PositionPoint."
+                },
+                "mRID": {
+                    "label": "cim:IdentifiedObject.mRID",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "name": {
+                    "label": "cim:IdentifiedObject.name",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        },
+        "PositionPoint": {
+            "rdf_type": " rdf:ID=\"",
+            "label": "cim:PositionPoint",
+            "fields": {
+                "Location": {
+                    "label": "cim:PositionPoint.Location",
+                    "data_type": " rdf:resource=\"#",
+                    "data_type_prim": " rdf:resource=\"#"
+                },
+                "sequenceNumber": {
+                    "label": "cim:PositionPoint.sequenceNumber",
+                    "data_type": "Integer",
+                    "data_type_prim": "Integer"
+                },
+                "xPosition": {
+                    "label": "cim:PositionPoint.xPosition",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "yPosition": {
+                    "label": "cim:PositionPoint.yPosition",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                },
+                "zPosition": {
+                    "label": "cim:PositionPoint.zPosition",
+                    "data_type": "String",
+                    "data_type_prim": "String"
+                }
+            }
+        }
+    }
+}

--- a/pandapower/test/converter/test_from_cim.py
+++ b/pandapower/test/converter/test_from_cim.py
@@ -315,17 +315,29 @@ def test_Simbench_1_EHV_mixed__2_no_sw_res_dcline(Simbench_1_EHV_mixed__2_no_sw)
 
 
 def test_Simbench_1_EHV_mixed__2_no_sw_measurement(Simbench_1_EHV_mixed__2_no_sw):
-    assert len(Simbench_1_EHV_mixed__2_no_sw.measurement.index) == 571
+    assert len(Simbench_1_EHV_mixed__2_no_sw.measurement.index) == 1142
     element_0 = Simbench_1_EHV_mixed__2_no_sw.measurement[
-        Simbench_1_EHV_mixed__2_no_sw.measurement['element'] ==
+        (Simbench_1_EHV_mixed__2_no_sw.measurement['element'] ==
         Simbench_1_EHV_mixed__2_no_sw.bus[Simbench_1_EHV_mixed__2_no_sw.bus[
-                                              'origin_id'] == '_1cdc1d88-56de-465b-b1a0-968722f2b287'].index[0]]
+                                              'origin_id'] == '_1cdc1d88-56de-465b-b1a0-968722f2b287'].index[0]) &
+        (Simbench_1_EHV_mixed__2_no_sw.measurement['measurement_type'] == 'v')]
     assert element_0['name'].item() == 'EHV Bus 1'
     assert element_0['measurement_type'].item() == 'v'
     assert element_0['element_type'].item() == 'bus'
     assert element_0['value'].item() == pytest.approx(1.0920, abs=0.000001)
     assert element_0['std_dev'].item() == pytest.approx(0.001092, abs=0.000001)
     assert element_0['side'].item() is None
+    element_1 = Simbench_1_EHV_mixed__2_no_sw.measurement[
+        (Simbench_1_EHV_mixed__2_no_sw.measurement['element'] ==
+        Simbench_1_EHV_mixed__2_no_sw.bus[Simbench_1_EHV_mixed__2_no_sw.bus[
+                                              'origin_id'] == '_1cdc1d88-56de-465b-b1a0-968722f2b287'].index[0]) &
+        (Simbench_1_EHV_mixed__2_no_sw.measurement['measurement_type'] == 'angle')]
+    assert element_1['name'].item() == 'EHV Bus 1'
+    assert element_1['measurement_type'].item() == 'angle'
+    assert element_1['element_type'].item() == 'bus'
+    assert element_1['value'].item() == pytest.approx(0.0, abs=0.000001)
+    assert element_1['std_dev'].item() == pytest.approx(0.001, abs=0.000001)
+    assert element_1['side'].item() is None
 
 
 def test_SimBench_1_HVMVmixed_1_105_0_sw_modified_res_xward(SimBench_1_HVMVmixed_1_105_0_sw_modified):

--- a/tutorials/ltds2pp.ipynb
+++ b/tutorials/ltds2pp.ipynb
@@ -1,0 +1,105 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "50f680ff",
+   "metadata": {},
+   "source": " # Converting a grid model from LTDS to pandapower\n"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25b136f3",
+   "metadata": {},
+   "source": [
+    "Import the pandapower library and the neccessary methods for the conversion as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "5cb1fd35",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "source": [
+    "from pandapower.converter.cim import from_cim as cim2pp\n",
+    "import warnings\n",
+    "warnings.simplefilter(action='ignore', category=FutureWarning)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f4cf251",
+   "metadata": {},
+   "source": [
+    "## LTDS to pandapower\n",
+    "\n",
+    "First, we define the LTDS zip archive, which can be converted to pandapower. Then call the converter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "f066a777",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "source": [
+    "# ltds_files is a list containing paths to files needed for the LTDS converter:\n",
+    "ltds_files = [r\"path-to-ltds-zip\"]\n",
+    "\n",
+    "# set the create_tap_controller flag to false if you don't have access to an SSH-profile\n",
+    "net = cim2pp.from_cim(file_list=ltds_files, cgmes_version='LTDS', create_tap_controller=False)\n",
+    "\n",
+    "print('Conversion successful')"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80ec6e0d",
+   "metadata": {},
+   "source": [
+    "## Get an overview over your grid\n",
+    "Once the network is converted to pandapower, the data can be displayed:"
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "# print an overview over the nodes and lines\n",
+    "print(f\"Overview over the nodes: {net.bus.describe()}\")\n",
+    "print(f\"Some nodes: {net.bus.loc[:5]}\")\n",
+    "print(f\"Overview over the lines: {net.line.describe()}\")\n",
+    "print(f\"Some lines: {net.line.loc[:5]}\")"
+   ],
+   "id": "e1733f6b519a1b26",
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
In convert_format, an error is raised in case a network is converted with newer format version than the currently installed pandapower version. There is a flag in case a user wants to open a newer network, but this must be actively chosen.

    in the version checks within convert_format, an error is raised if a network with newer format version than the currently installed pandapower version shall be opened
    there is an option to ignore this check and only print out a warning
    removal of the check_net_version function, as this was moved to convert_format and is explicitely used to avoid loading newer network formats than pandapower can handle

Why is this important?
It should be more user friendly to not let a user open a network with a format that is not supported by his installed pandapower version. If this error is not identified, some functions of pandapower might fail or produce wrong results unnoticed. The user should explicitly accept this risk instead of just printing a warning, as altering the network data could ultimately end in a network model that pandapower cannot handle anymore at all.